### PR TITLE
Release 1.1.1

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4.1.6
+        uses: actions/checkout@v4.1.7
 
       - name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@v5.0.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Pre-commit
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4.1.6
+        uses: actions/checkout@v4.1.7
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         uses: actions/setup-python@v5.1.0
         with:
@@ -38,7 +38,7 @@ jobs:
     name: HACS
     steps:
       - name: Check out the repository
-        uses: "actions/checkout@v4.1.6"
+        uses: "actions/checkout@v4.1.7"
 
       - name: HACS validation
         uses: "hacs/action@22.5.0"
@@ -51,7 +51,7 @@ jobs:
     name: Hassfest
     steps:
       - name: Check out the repository
-        uses: "actions/checkout@v4.1.6"
+        uses: "actions/checkout@v4.1.7"
 
       - name: Hassfest validation
         uses: "home-assistant/actions/hassfest@master"

--- a/custom_components/smartcocoon/__init__.py
+++ b/custom_components/smartcocoon/__init__.py
@@ -95,10 +95,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][config_entry.entry_id] = smartcocoon
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(config_entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     config_entry.async_on_unload(config_entry.add_update_listener(async_update_options))
 

--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["smartcocoon"],
   "requirements": ["pysmartcocoon==1.1.0"],
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name        = "hacs_smartcocoon"
-version     = "v1.1.0"
+version     = "v1.1.1"
 license     = {text = "MIT"}
 description = "SmartCocoon integration with Home Assistant."
 readme      = "README.md"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,4 +4,4 @@ isort==5.13.2
 black==24.4.2
 pylint==3.2.2
 pre-commit==3.7.1
-reorder-python-imports==3.12.0
+reorder-python-imports==3.13.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,6 +2,6 @@
 pytest-homeassistant-custom-component==0.13.128
 isort==5.13.2
 black==24.4.2
-pylint==3.2.2
+pylint==3.2.5
 pre-commit==3.7.1
 reorder-python-imports==3.12.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest-homeassistant-custom-component==0.13.144
+pytest-homeassistant-custom-component==0.13.145
 isort==5.13.2
 black==24.4.2
 pylint==3.2.5

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest-homeassistant-custom-component==0.13.128
+pytest-homeassistant-custom-component==0.13.144
 isort==5.13.2
 black==24.4.2
 pylint==3.2.2


### PR DESCRIPTION
Bump reorder-python-imports from 3.12.0 to 3.13.0
Bump actions/checkout from 4.1.6 to 4.1.7
Bump pylint from 3.2.2 to 3.2.5
Bump pytest-homeassistant-custom-component from 0.13.128 to 0.13.145
Switched to async_forward_entry_setups
Bump to 1.1.1