### PR TITLE
Bump pysmartcocoon 1.2.4 -> 1.2.5 and other dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:3.12
+FROM mcr.microsoft.com/devcontainers/python:3.13
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ on:
     - cron: "0 0 * * *"
 
 env:
-  DEFAULT_PYTHON: "3.12"
+  DEFAULT_PYTHON: "3.13"
 
 jobs:
   pre-commit:

--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["smartcocoon"],
-  "requirements": ["pysmartcocoon==1.2.4"],
+  "requirements": ["pysmartcocoon==1.2.5"],
   "version": "1.1.3"
 }

--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["smartcocoon"],
   "requirements": ["pysmartcocoon==1.2.5"],
-  "version": "1.1.3"
+  "version": "1.1.4"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name        = "hacs_smartcocoon"
-version     = "v1.1.3"
+version     = "v1.1.4"
 license     = {text = "MIT"}
 description = "SmartCocoon integration with Home Assistant."
 readme      = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Home Automation",
 ]
-requires-python = ">=3.12.0"
+requires-python = ">=3.13.0"
 
 [tool.pylint.BASIC]
 class-const-naming-style = "any"
@@ -35,7 +35,7 @@ good-names = [
 ]
 
 [tool.pylint.MAIN]
-py-version = "3.12"
+py-version = "3.13"
 ignore = [
     "tests",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-homeassistant>=2024.8.0
+homeassistant>=2024.14.0
 pysmartcocoon==1.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 homeassistant>=2024.8.0
-pysmartcocoon==1.2.4
+pysmartcocoon==1.2.5

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,8 +1,8 @@
 -r requirements.txt
-pytest-homeassistant-custom-component==0.13.154
+pytest-homeassistant-custom-component==0.13.236
 isort==5.13.2
 black==24.4.2
 pylint==3.3.5
-pre-commit==3.7.1
+pre-commit==4.1.0
 reorder-python-imports==3.14.0
 pre-commit==4.1.0


### PR DESCRIPTION
Bump pysmartcocoon 1.2.4 -> 1.2.5 to resolve issue #233 
Bump Python to 3.13 and homeassistant min to 2024.12.0
Bump test dependencies
Bump Python 3.12 -> 3.13
Bump version 1.1.3 -> 1.1.4