### PR TITLE
ci/python: enforce Python 3.13.2 across project

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:3.13
+FROM mcr.microsoft.com/devcontainers/python:3.13.2
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ on:
     - cron: "0 0 * * *"
 
 env:
-  DEFAULT_PYTHON: "3.13"
+  DEFAULT_PYTHON: "3.13.2"
 
 jobs:
   pre-commit:

--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -8,6 +8,5 @@
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["smartcocoon"],
   "requirements": ["pysmartcocoon==1.2.5"],
-  "min_homeassistant_version": "2025.5.0",
   "version": "1.1.4"
 }

--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -8,5 +8,6 @@
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["smartcocoon"],
   "requirements": ["pysmartcocoon==1.2.5"],
+  "min_homeassistant_version": "2025.5.0",
   "version": "1.1.4"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "SmartCocoon",
   "render_readme": true,
-  "homeassistant": "2024.8.0",
+  "homeassistant": "2025.5.0",
   "hacs": "1.34.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Home Automation",
 ]
-requires-python = ">=3.13.0"
+requires-python = ">=3.13.2"
 
 [tool.pylint.BASIC]
 class-const-naming-style = "any"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-homeassistant>=2024.14.0
+homeassistant>=2025.5.0
 pysmartcocoon==1.2.5


### PR DESCRIPTION
Pin Python 3.13.2 in pyproject, CI, devcontainer, and .python-version. Also bump min Home Assistant to 2025.5.0 in hacs.json, requirements and manifest.