### PR TITLE
Fix: use power_percentage for fan speed mapping

### DIFF
--- a/custom_components/smartcocoon/fan.py
+++ b/custom_components/smartcocoon/fan.py
@@ -142,8 +142,14 @@ class SmartCocoonFan(FanEntity):  # type: ignore[misc]
     def percentage(self) -> int | None:
         """Return the current speed as a percentage (0-100)."""
         fan_data = self._get_fan_data()
-        power = fan_data.power
-        return int(power)
+        percentage = fan_data.power_percentage
+        _LOGGER.debug(
+            "Fan %s: Power percentage from pysmartcocoon: %s (type: %s)",
+            self._fan_id,
+            percentage,
+            type(percentage),
+        )
+        return int(percentage)
 
     @property
     def preset_mode(self) -> str | None:

--- a/tests/const.py
+++ b/tests/const.py
@@ -14,7 +14,7 @@ MOCK_FAN_DATA = {
         "room_name": "Living Room",
         "connected": True,
         "fan_on": True,
-        "power": 75,
+        "power_percentage": 75,  # pysmartcocoon power_percentage is 0-100 scale
         "mode": "auto",
         "firmware_version": "1.0.0",
     },

--- a/tests/test_final.py
+++ b/tests/test_final.py
@@ -409,7 +409,7 @@ async def test_smartcocoon_fan_async_methods(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -466,7 +466,7 @@ async def test_smartcocoon_fan_invalid_preset_mode(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -488,7 +488,7 @@ async def test_smartcocoon_fan_unsupported_preset_mode(hass: HomeAssistant) -> N
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -516,7 +516,7 @@ async def test_smartcocoon_fan_turn_on_with_preset_mode(hass: HomeAssistant) -> 
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -543,7 +543,7 @@ async def test_smartcocoon_fan_turn_on_with_percentage(hass: HomeAssistant) -> N
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -574,7 +574,7 @@ def test_smartcocoon_fan_without_preset_modes(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -596,7 +596,7 @@ def test_smartcocoon_fan_device_info(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -623,7 +623,7 @@ def test_smartcocoon_fan_extra_state_attributes(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -646,7 +646,7 @@ async def test_smartcocoon_fan_update_callback(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -669,7 +669,7 @@ def test_smartcocoon_fan_basic_properties(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -701,7 +701,7 @@ def test_smartcocoon_fan_supported_features(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -729,7 +729,7 @@ def test_smartcocoon_fan_preset_modes(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -760,7 +760,7 @@ def test_smartcocoon_fan_get_fan_data_without_scmanager(hass: HomeAssistant) -> 
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -894,7 +894,7 @@ async def test_smartcocoon_fan_error_handling_invalid_preset_mode_format(
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -919,7 +919,7 @@ async def test_smartcocoon_fan_error_handling_preset_mode_fstring_fixed(
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -135,7 +135,7 @@ def test_fan_entity_basic_properties() -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power=75,  # API returns 0-100 scale, same as HA
+            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )


### PR DESCRIPTION
This PR updates the fan speed mapping to use SmartCocoon's reported power percentage directly.\n\nChanges:\n- Use fan_data.power_percentage as the source of truth for speed\n\nVerification:\n- Local tests pass\n- Manual verification against device data\n\nCommit(s):\n4ccb647 fix: use fan_data.power_percentage directly for fan speed