### PR TITLE
fix: use speed_pct instead of power_percentage

### DIFF
--- a/custom_components/smartcocoon/error_handler.py
+++ b/custom_components/smartcocoon/error_handler.py
@@ -1,0 +1,101 @@
+"""Error handling module for SmartCocoon integration."""
+
+import asyncio
+from collections.abc import Coroutine
+from dataclasses import dataclass
+import logging
+import random
+from typing import Any, Callable, TypeVar
+
+from pysmartcocoon.errors import RequestError, SmartCocoonError, UnauthorizedError
+
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+_LOGGER = logging.getLogger(__name__)
+
+R = TypeVar("R")  # Return type of the operation
+
+
+@dataclass
+class RetryConfig:
+    """Configuration for retry logic."""
+
+    max_attempts: int = 3
+    base_delay: float = 1.0  # seconds
+    max_delay: float = 30.0  # seconds
+    exponential_base: float = 2.0
+    jitter: bool = True
+
+
+class SmartCocoonErrorHandler:
+    """Handles errors and implements retry logic for SmartCocoon API calls."""
+
+    def __init__(self, retry_config: RetryConfig | None = None) -> None:
+        """Initialize the error handler."""
+        self._retry_config = retry_config if retry_config else RetryConfig()
+
+    async def async_retry_operation(
+        self,
+        operation: Callable[..., Coroutine[Any, Any, R]],
+        operation_name: str = "API operation",
+        context: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> R:
+        """Retry an asynchronous operation with exponential backoff and jitter."""
+        context = context if context is not None else {}
+        for attempt in range(self._retry_config.max_attempts):
+            try:
+                return await operation(**kwargs)
+            except UnauthorizedError as exc:
+                _LOGGER.error(
+                    "Authentication failed for %s (attempt %d/%d). Context: %s",
+                    operation_name,
+                    attempt + 1,
+                    self._retry_config.max_attempts,
+                    context,
+                )
+                # Convert UnauthorizedError to ConfigEntryAuthFailed for HA integration
+                raise ConfigEntryAuthFailed("Authentication failed") from exc
+            except (RequestError, SmartCocoonError, asyncio.TimeoutError) as exc:
+                if attempt == self._retry_config.max_attempts - 1:
+                    _LOGGER.error(
+                        "Failed to complete %s after %d attempts. Context: %s. Error: %s",
+                        operation_name,
+                        self._retry_config.max_attempts,
+                        context,
+                        exc,
+                    )
+                    raise exc
+
+                delay = self._calculate_delay(attempt)
+                _LOGGER.warning(
+                    "Attempt %d/%d for %s failed. Retrying in %.2f seconds. Context: %s. Error: %s",
+                    attempt + 1,
+                    self._retry_config.max_attempts,
+                    operation_name,
+                    delay,
+                    context,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+            except Exception as exc:
+                _LOGGER.exception(
+                    "An unexpected error occurred during %s (attempt %d/%d). Context: %s",
+                    operation_name,
+                    attempt + 1,
+                    self._retry_config.max_attempts,
+                    context,
+                )
+                raise exc
+        raise RuntimeError(
+            "Should not reach here: retry logic exhausted without raising an exception."
+        )
+
+    def _calculate_delay(self, attempt: int) -> float:
+        """Calculate the delay for the next retry attempt."""
+        delay = self._retry_config.base_delay * (
+            self._retry_config.exponential_base**attempt
+        )
+        if self._retry_config.jitter:
+            delay = random.uniform(0, delay)
+        return min(delay, self._retry_config.max_delay)

--- a/custom_components/smartcocoon/error_handler.py
+++ b/custom_components/smartcocoon/error_handler.py
@@ -80,7 +80,7 @@ class SmartCocoonErrorHandler:
                     exc,
                 )
                 await asyncio.sleep(delay)
-            except Exception as exc:
+            except Exception as exc:  # pylint: disable=broad-exception-caught
                 if self._retry_config.retry_generic_exceptions:
                     if attempt == self._retry_config.max_attempts - 1:
                         _LOGGER.error(
@@ -91,7 +91,7 @@ class SmartCocoonErrorHandler:
                             exc,
                         )
                         raise exc
-                    
+
                     delay = self._calculate_delay(attempt)
                     _LOGGER.warning(
                         "Attempt %d/%d for %s failed with unexpected error. Retrying in %.2f seconds. Context: %s. Error: %s",

--- a/custom_components/smartcocoon/fan.py
+++ b/custom_components/smartcocoon/fan.py
@@ -143,14 +143,14 @@ class SmartCocoonFan(FanEntity):  # type: ignore[misc]
     def percentage(self) -> int | None:
         """Return the current speed as a percentage (0-100)."""
         fan_data = self._get_fan_data()
-        power = fan_data.power_percentage
+        speed_pct = fan_data.speed_pct
         _LOGGER.debug(
-            "Fan %s: Raw power value from pysmartcocoon: %s (type: %s)",
+            "Fan %s: Speed percentage from pysmartcocoon: %s (type: %s)",
             self._fan_id,
-            power,
-            type(power),
+            speed_pct,
+            type(speed_pct),
         )
-        percentage = int(power)
+        percentage = int(speed_pct)
         _LOGGER.debug("Fan %s: Converted to percentage: %s", self._fan_id, percentage)
         return percentage
 

--- a/tests/const.py
+++ b/tests/const.py
@@ -14,7 +14,7 @@ MOCK_FAN_DATA = {
         "room_name": "Living Room",
         "connected": True,
         "fan_on": True,
-        "power_percentage": 75,  # pysmartcocoon power_percentage is 0-100 scale
+        "speed_pct": 75,  # pysmartcocoon speed_pct is 0-100 scale
         "mode": "auto",
         "firmware_version": "1.0.0",
     },

--- a/tests/test_final.py
+++ b/tests/test_final.py
@@ -409,7 +409,7 @@ async def test_smartcocoon_fan_async_methods(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -470,7 +470,7 @@ async def test_smartcocoon_fan_invalid_preset_mode(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -492,7 +492,7 @@ async def test_smartcocoon_fan_unsupported_preset_mode(hass: HomeAssistant) -> N
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -520,7 +520,7 @@ async def test_smartcocoon_fan_turn_on_with_preset_mode(hass: HomeAssistant) -> 
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -547,7 +547,7 @@ async def test_smartcocoon_fan_turn_on_with_percentage(hass: HomeAssistant) -> N
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -583,7 +583,7 @@ def test_smartcocoon_fan_without_preset_modes(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -605,7 +605,7 @@ def test_smartcocoon_fan_device_info(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -632,7 +632,7 @@ def test_smartcocoon_fan_extra_state_attributes(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -655,7 +655,7 @@ async def test_smartcocoon_fan_update_callback(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -678,7 +678,7 @@ def test_smartcocoon_fan_basic_properties(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -710,7 +710,7 @@ def test_smartcocoon_fan_supported_features(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -738,7 +738,7 @@ def test_smartcocoon_fan_preset_modes(hass: HomeAssistant) -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -769,7 +769,7 @@ def test_smartcocoon_fan_get_fan_data_without_scmanager(hass: HomeAssistant) -> 
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -903,7 +903,7 @@ async def test_smartcocoon_fan_error_handling_invalid_preset_mode_format(
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )
@@ -928,7 +928,7 @@ async def test_smartcocoon_fan_error_handling_preset_mode_fstring_fixed(
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -135,7 +135,7 @@ def test_fan_entity_basic_properties() -> None:
             room_name="Living Room",
             connected=True,
             fan_on=True,
-            power_percentage=75,  # pysmartcocoon power_percentage is 0-100 scale
+            speed_pct=75,  # pysmartcocoon speed_pct is 0-100 scale
             mode="auto",
             firmware_version="1.0.0",
         )


### PR DESCRIPTION
This PR fixes a critical runtime error in Home Assistant.

## Problem
- AttributeError: 'Fan' object has no attribute 'power_percentage'
- The pysmartcocoon library uses 'speed_pct' not 'power_percentage'

## Solution
- Use correct pysmartcocoon attribute: speed_pct
- speed_pct returns the power as a percentage (0-100)
- Updated logging messages to reflect correct attribute name

## Impact
- Resolves runtime error that prevents fan entities from working
- Maintains same functionality with correct attribute access
- No breaking changes to user interface

## Testing
- Fixes the AttributeError reported in Home Assistant logs
- Fan percentage display should work correctly