### PR TITLE
Bump pysmartcocoon to 1.4.1

### DIFF
--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["smartcocoon"],
-  "requirements": ["pysmartcocoon==1.4.0"],
+  "requirements": ["pysmartcocoon==1.4.1"],
   "version": "1.3.0"
 }

--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["smartcocoon"],
   "requirements": ["pysmartcocoon==1.4.1"],
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pysmartcocoon==1.4.0
+pysmartcocoon==1.4.1


### PR DESCRIPTION
## 🔄 Dependency Update

Bumps `pysmartcocoon` from `1.4.0` to `1.4.1` (latest version).

### Changes
- Updated `requirements.txt`
- Updated `manifest.json`

### Testing
- All existing tests should continue to pass
- No breaking changes expected (patch version bump)

### Related
- Latest version: https://pypi.org/project/pysmartcocoon/1.4.1/