### PR TITLE
fix(ci): correct head-branch syntax in labeler config

### DIFF
--- a/.github/labeler-config.yml
+++ b/.github/labeler-config.yml
@@ -68,30 +68,22 @@ style:
       - any-glob-to-any-file: "**/isort.cfg"
 
 # Label based on branch name patterns
+# actions/labeler v5+ expects head-branch to be a list of regular expressions,
+# not a list of `pattern:` maps, and matches them as regex rather than globs.
 hotfix:
-  - head-branch:
-      - pattern: "hotfix/**"
+  - head-branch: ["^hotfix/"]
 
 feature:
-  - head-branch:
-      - pattern: "feature/**"
-      - pattern: "feat/**"
+  - head-branch: ["^feature/", "^feat/"]
 
 bugfix:
-  - head-branch:
-      - pattern: "bugfix/**"
-      - pattern: "fix/**"
+  - head-branch: ["^bugfix/", "^fix/"]
 
 housekeeping:
-  - head-branch:
-      - pattern: "housekeeping/**"
-      - pattern: "chore/**"
+  - head-branch: ["^housekeeping/", "^chore/"]
 
 release:
-  - head-branch:
-      - pattern: "release/**"
-      - pattern: "bump/**"
+  - head-branch: ["^release/", "^bump/"]
 
 dependabot:
-  - head-branch:
-      - pattern: "dependabot/**"
+  - head-branch: ["^dependabot/"]


### PR DESCRIPTION
## Problem

The `Auto-label PRs` job has been failing on **every** open PR in this repo, regardless of content — all 9 open dependabot PRs show a red check because of it, which makes it impossible to tell a genuinely broken PR from a healthy one. `main` itself is green.

## Cause

`.github/labeler-config.yml` used the v4-era shape for branch rules:

```yaml
hotfix:
  - head-branch:
      - pattern: "hotfix/**"
```

`actions/labeler` v5+ expects `head-branch` to be **a list of regular expression strings**, not a list of `pattern:` maps. The values were also globs (`hotfix/**`) where v5+ matches by regex.

The `changed-files` rules were already in valid v5 form and are untouched.

## Fix

```yaml
hotfix:
  - head-branch: ["^hotfix/"]
```

Applied to all six branch rules. All 14 labels referenced by the config already exist in the repo, so nothing else is needed.

## Verification

This PR is on a `fix/` branch, so a working labeler should apply the **`bugfix`** label to it and the `Auto-label PRs` check should pass — that is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)