### PR TITLE
ci: auto-merge dependabot patch and minor updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,43 @@
+---
+name: Dependabot auto-merge
+
+# `pull_request_target` is required so the token can act on the PR, but it
+# means this workflow runs in the context of the base repository with write
+# access. It therefore MUST NOT check out or execute any code from the pull
+# request -- it only reads dependabot's metadata and calls the merge API.
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Belt and braces: the event is restricted to dependabot's own PRs, and
+    # fetch-metadata below fails on anything it did not author.
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Only patch and minor updates merge unattended. Majors are left open
+      # deliberately: they are where breaking changes live, and CI passing is
+      # not sufficient evidence that an upgrade is safe to ship.
+      - name: Enable auto-merge for patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Note major updates left for review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          echo "::notice::Major update to \
+          ${{ steps.metadata.outputs.dependency-names }} left open for review."


### PR DESCRIPTION
## Why

Nine dependabot PRs are open here, the oldest from December. They sat while CI was disabled and nobody noticed. Routine chores should not need a human.

## Behaviour

| Update type | Action |
|---|---|
| patch | auto-merge once all required checks pass |
| minor | auto-merge once all required checks pass |
| **major** | **left open for review** |

Majors are deliberately excluded — that is where breaking changes live, and green CI is not sufficient evidence that an upgrade is safe to ship.

## What gates it

- **Branch protection** on `main` now requires `Pre-commit`, `Test Python 3.13`, `Security Scan`, `HACS`, `Hassfest`. `--auto` waits for all of them rather than merging on arrival.
- **Dependabot cooldown** (added in #388) means nothing lands within days of publication, so a compromised release has time to be caught and yanked.

## Security note on `pull_request_target`

This event is required for the token to act on the PR, and it runs with **write access in the base repository context**. The workflow therefore never checks out or executes pull request code — it only reads dependabot's metadata and calls the merge API. The job is additionally gated on `github.actor == 'dependabot[bot]'`, and `fetch-metadata` itself fails on PRs it did not author.

`dependabot/fetch-metadata` is pinned to a commit SHA, consistent with #388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)