### PR TITLE
fix(ci): drop unsupported cooldown keys for github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,10 @@ updates:
     # Raise pull requests for version updates
     # to github-actions against the `main` branch
     target-branch: "main"
+    # github-actions supports only `default-days`; the semver-* keys are
+    # rejected for this ecosystem.
     cooldown:
       default-days: 5
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
   - package-ecosystem: pip
     directory: "/.github/workflows"
     schedule:


### PR DESCRIPTION
Dependabot rejected the config added in #388:

```
The property '#/updates/0/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/0/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/0/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

The `github-actions` ecosystem accepts only `default-days`. My mistake — I applied the same block to all three ecosystems.

This matters beyond tidiness: **an invalid config means dependabot parses none of it**, so the cooldown was not actually in effect for any ecosystem, including the pip ones where the keys are valid. The `pip` entries keep the full per-severity schedule.

Caught by the `.github/dependabot.yml` validation check, which only became visible once a PR was opened after #388 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)