### PR TITLE
Release v1.3.3: pick up credential redaction from pysmartcocoon 1.4.3

### DIFF
--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["smartcocoon"],
-  "requirements": ["pysmartcocoon==1.4.2"],
-  "version": "1.3.2"
+  "requirements": ["pysmartcocoon==1.4.3"],
+  "version": "1.3.3"
 }

--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/davecpearce/hacs_smartcocoon/blob/main/README.md",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
-  "loggers": ["smartcocoon"],
+  "loggers": ["pysmartcocoon"],
   "requirements": ["pysmartcocoon==1.4.3"],
   "version": "1.3.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name        = "hacs_smartcocoon"
-version     = "v1.3.2"
+version     = "v1.3.3"
 license     = {text = "MIT"}
 description = "SmartCocoon integration with Home Assistant."
 readme      = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pysmartcocoon==1.4.1
+pysmartcocoon==1.4.3


### PR DESCRIPTION
## Why this release matters

`pysmartcocoon 1.4.3` (published today) stops writing credentials into debug logs — the account **password**, bearer token, API client id, and per-fan `mqtt_password` were all being dumped in plaintext when debug logging was enabled.

**Home Assistant installs the version pinned in `manifest.json`, not the latest.** Until this pin moves, every HA user keeps running 1.4.2 and keeps leaking. Fixing the library was only half the job.

## Changes

| File | From | To |
|---|---|---|
| `manifest.json` requirements | `pysmartcocoon==1.4.2` | `pysmartcocoon==1.4.3` |
| `requirements.txt` | `pysmartcocoon==1.4.1` | `pysmartcocoon==1.4.3` |
| `manifest.json` loggers | `["smartcocoon"]` | `["pysmartcocoon"]` |
| `manifest.json` version | `1.3.2` | `1.3.3` |
| `pyproject.toml` version | `v1.3.2` | `v1.3.3` |

## The pin drift

`requirements.txt` was on **1.4.1** while `manifest.json` was on **1.4.2**. Local test runs therefore resolved a different library version than Home Assistant actually installed — the kind of gap where a library fix looks broken locally, or looks fine locally while users get something else. Both now say 1.4.3.

## The logger namespace

`loggers: ["smartcocoon"]` matched **nothing**. Verified: the library logs under `pysmartcocoon.{api,fan,manager}` via `getLogger(__name__)`, and the integration's own modules log under `custom_components.smartcocoon.*`, which Home Assistant wires up itself. No logger anywhere is named `smartcocoon`.

So Home Assistant's per-integration debug toggle enabled nothing from the library. Users had to know to add `pysmartcocoon: debug` to `configuration.yaml` by hand, as the library README instructs.

**Sequencing matters here:** before 1.4.3, fixing this would have made the UI toggle start writing account passwords to the log. It is only safe because redaction ships in the pinned version. That is why it is in *this* release and not an earlier one.

## User advice for the release notes

Anyone who enabled debug logging for this integration should **treat their SmartCocoon password as exposed** — rotate it, and check any logs shared publicly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)