### PR TITLE
chore: bump ruff and pylint in both places they are pinned

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: trailing-whitespace
   # Formatting handled by Ruff (ruff-format); Black removed to avoid conflicts
   - repo: https://github.com/pycqa/pylint
-    rev: v4.0.1
+    rev: v4.0.6
     hooks:
       - id: pylint
         args:
@@ -30,7 +30,7 @@ repos:
         additional_dependencies:
           - pbr
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/custom_components/smartcocoon/connection_monitor.py
+++ b/custom_components/smartcocoon/connection_monitor.py
@@ -297,10 +297,7 @@ class ConnectionMonitor:
                     return
 
                 _LOGGER.debug(
-                    (
-                        "No in-memory fan entity object matched _fan_id=%s for "
-                        "entity %s"
-                    ),
+                    ("No in-memory fan entity object matched _fan_id=%s for entity %s"),
                     fan_id,
                     entity_id,
                 )

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,14 +9,14 @@ pytest-timeout==2.4.0
 # installs whatever released overnight, so a new tool version can turn main
 # red with no code change. Dependabot proposes the upgrades instead.
 #
-# pylint and mypy are kept equal to the `rev` pinned for them in
-# .pre-commit-config.yaml. Those hooks run in their own isolated environments
-# in CI, so a different version here would only mean local runs disagreeing
-# with CI over the same code.
-pylint==4.0.1
+# pylint, ruff and mypy are kept equal to the `rev` pinned for them in
+# .pre-commit-config.yaml, and must be bumped in both places together. Those
+# hooks run in their own isolated environments in CI, so a version that
+# differs here only means local runs disagreeing with CI over the same code.
+pylint==4.0.6
 pre-commit==4.5.1
 # Ruff replaces black/isort and handles imports/formatting
-ruff==0.14.10
+ruff==0.16.1
 ruff-lsp==0.0.62
 # Security scanning tools (semgrep, pip-audit) are deliberately NOT listed
 # here. They are standalone CLIs, and installing them alongside homeassistant


### PR DESCRIPTION
## The drift

`ruff` was pinned in two places that had come badly out of step:

| | Version |
|---|---|
| `requirements_test.txt` (what you install locally) | `0.14.10` |
| `.pre-commit-config.yaml` (**what actually gates CI**) | `v0.6.9` |

Roughly **eight minor releases apart**. Pre-commit is the gate, so the linter and formatter enforced on a PR were not the ones a developer runs locally — identical code could pass in one place and fail in the other. That is the exact failure mode `DEVELOPMENT.md` warns about under "Keeping Versions in Sync".

`pylint` and `mypy` were already aligned (#388); ruff was missed.

## The fix

Both sides bumped together:

```
ruff    0.14.10 -> 0.16.1   (pre-commit v0.6.9 -> v0.16.1)
pylint  4.0.1   -> 4.0.6    (pre-commit v4.0.1 -> v4.0.6)
```

## Why not just merge the dependabot PRs

#395 (ruff) and #391 (pylint) bump **only `requirements_test.txt`**. Merging them would have widened the gap rather than closed it — and #391 would have re-broken the pylint alignment that #388 established.

Dependabot cannot see the pre-commit `rev` as part of the same pin, so it can only ever propose half the change. **These two need bumping by hand, together.** Worth remembering next time they appear.

## Impact

Smaller than the version jump suggests:

- `ruff format` reformats **one line** in `connection_monitor.py` — the accumulated result of eight minor versions of formatter changes CI was never applying.
- `ruff check` passes unchanged.
- `pylint 4.0.6` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)