### PR TITLE
fix(ci): stop dependabot proposing bumps it cannot satisfy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,5 +43,13 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+    # pytest-homeassistant-custom-component pins each of these to an exact
+    # version, so bumping one on its own is unsatisfiable and the pull
+    # request can never go green. They move when that package moves.
+    # `homeassistant` was already listed here for the same reason.
     ignore:
       - dependency-name: "homeassistant"
+      - dependency-name: "pytest"
+      - dependency-name: "pytest-asyncio"
+      - dependency-name: "pytest-cov"
+      - dependency-name: "pytest-timeout"


### PR DESCRIPTION
## The problem

`pytest-homeassistant-custom-component` pins several test dependencies to **exact** versions:

```
pytest==9.0.0
pytest-asyncio==1.3.0
pytest-cov==7.0.0
pytest-timeout==2.4.0
homeassistant==2026.2.3
```

`requirements_test.txt` pins three of those separately at the same values. So any dependabot bump to one of them is unsatisfiable and the PR can **never** go green:

```
Cannot install -r requirements_test.txt (line 3) and pytest-cov==7.1.0
  pytest-homeassistant-custom-component 0.13.316 depends on pytest-cov==7.0.0
```

That is why #385 sat open failing since **March**. It was never about 7.1.0 specifically — any bump would have failed identically. These versions aren't ours to choose; they move when the Home Assistant test harness moves.

## The fix

Add them to dependabot's ignore list. `homeassistant` was **already** listed there for exactly this reason — so the pattern was understood, but only one instance of it had ever been handled.

#385 is closed.

## Note

`pytest-mock` is deliberately **not** ignored — `pytest-homeassistant-custom-component` does not pin it, so bumps to it are legitimate and installable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)