### PR TITLE
chore: move to mypy 2, in both pins and the code it affects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
         types: [python]
   # Type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.2
+    rev: v2.1.0
     hooks:
       - id: mypy
         additional_dependencies: [types-requests, types-PyYAML]

--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from homeassistant.core import HomeAssistant
 
 
-@pytest.fixture  # type: ignore[misc]
+@pytest.fixture  # type: ignore[untyped-decorator]
 def _hass(hass: HomeAssistant) -> HomeAssistant:
     """Alias for hass fixture to avoid unused argument warnings."""
     return hass

--- a/custom_components/smartcocoon/config_flow.py
+++ b/custom_components/smartcocoon/config_flow.py
@@ -63,7 +63,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[misc
     VERSION = 1
 
     @staticmethod
-    @callback  # type: ignore[misc]
+    @callback  # type: ignore[untyped-decorator]
     def async_get_options_flow(
         config_entry: config_entries.ConfigEntry,
     ) -> config_entries.OptionsFlow:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -25,4 +25,4 @@ ruff-lsp==0.0.62
 # in isolation with pipx, and the pre-commit hook builds its own environment,
 # so both can track latest independently of homeassistant's pins.
 # Type checking
-mypy==1.18.2
+mypy==2.1.0


### PR DESCRIPTION
Supersedes #403, which bumps only `requirements_test.txt` and cannot work on its own.

## Why the dependabot PR could not work

mypy **renamed the error code** for an untyped decorator between 1.18.2 and 2.1.0: what was `misc` is now `untyped-decorator`. The suppression on `@callback` in `config_flow.py` only works on one version at a time:

| mypy | suppression | result |
|---|---|---|
| 1.18.2 | `ignore[untyped-decorator]` | ❌ `Unused "type: ignore"` + `Untyped decorator ... [misc]` |
| 2.1.0 | `ignore[misc]` | ❌ `Unused "type: ignore"` + `Untyped decorator ... [untyped-decorator]` |

So **the version bump and the code change must land in the same commit.** And #403 moved only `requirements_test.txt` — but pre-commit is what runs mypy in CI, and it pins its own `rev`, so that PR would not have changed CI's behaviour at all while breaking local runs.

Third instance of this pattern today, after ruff (#398) and pylint (#388): a tool pinned in two files, where dependabot can only ever see one of them.

## Changes

```
mypy  1.18.2 -> 2.1.0   (pre-commit v1.18.2 -> v2.1.0)
```

plus `# type: ignore[misc]` → `# type: ignore[untyped-decorator]` on the `@callback` decorator.

## A verification trap worth recording

I first ran mypy 2.1.0 in the project venv and saw **7 errors** — several `type: ignore` comments reported as redundant. Removing them would have broken CI.

The pre-commit hook runs mypy in an **isolated environment** with only `types-requests` and `types-PyYAML` — **no homeassistant**. There, HA imports resolve to `Any` and those ignores are still required. With homeassistant installed locally, HA is properly typed and they look redundant.

Re-running in a venv matching the hook's `additional_dependencies` gives the true picture: **2 errors, one line**. That is what this PR fixes.

Anything checking types here has to reproduce the hook's environment, not the project's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)