### PR TITLE
chore: replace archived prettier mirror and remove black leftovers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,8 +35,8 @@ repos:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.9.6
     hooks:
       - id: prettier
   # Security scanning hooks

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ test: ## Run tests
 lint: ## Run pre-commit hooks
 	pre-commit run --all-files
 
-format: ## Format code with Black (safe mode)
-	python -m black --safe custom_components/ tests/
+format: ## Format code with Ruff
+	python -m ruff format custom_components/ tests/
+	python -m ruff check --fix custom_components/ tests/
 
 ci-local: ## Run full CI locally
 	./scripts/run-ci-local.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,26 +27,6 @@ build-backend = "setuptools.build_meta"
 include = ["custom_components*"]
 exclude = ["node_modules*", "tests*", "scripts*"]
 
-[tool.black]
-line-length = 88
-target-version = ['py39']
-include = '\.pyi?$'
-# Note: Use 'python -m black --safe' to match pre-commit formatting
-extend-exclude = '''
-/(
-  # directories
-  \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | build
-  | dist
-)/
-'''
-# Note: Use 'pre-commit run black --all-files' to match CI formatting
-
 [tool.pylint.BASIC]
 class-const-naming-style = "any"
 good-names = [


### PR DESCRIPTION
## Prettier

`pre-commit/mirrors-prettier` is **archived upstream**, and its final tag is `v4.0.0-alpha.8` — which is what this repo was pinned to. An alpha from a dead repository gating every commit is not a good place to be, and there is no stable version to move to *within* that mirror, so bumping it was never an option.

Switched to **`rbubley/mirrors-prettier`** (actively maintained) on **`v3.9.6`** — a stable prettier 3.x rather than an alpha 4.

Note this is nominally a major *downgrade* (4-alpha → 3-stable). That is deliberate: prettier 4 has not shipped a stable release, and formatting rules from an alpha are not a sensible thing to enforce.

## Black leftovers

Black was replaced by ruff a while back, but three references outlived it:

- **`make format` still invoked black.** Anyone following the Makefile would have reformatted the tree with a tool CI does not run, then failed CI on the result. Now runs `ruff format` + `ruff check --fix`.
- **`pyproject.toml` still carried `[tool.black]`**, including a comment pointing at a pre-commit black hook that no longer exists.
- **`test_error_handling.py`** — an empty file at the repository root, outside `tests/`, collected by nothing.

`pyproject.toml` still parses; remaining tool sections are `coverage`, `pylint`, `pytest`, `ruff`, `setuptools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)