### PR TITLE
chore: pin pysmartcocoon 1.4.4

### DIFF
--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["pysmartcocoon"],
-  "requirements": ["pysmartcocoon==1.4.3"],
+  "requirements": ["pysmartcocoon==1.4.4"],
   "version": "1.3.3"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pysmartcocoon==1.4.3
+pysmartcocoon==1.4.4


### PR DESCRIPTION
Answering the question directly: **yes, HACS does need the pin bumped for 1.4.4 to reach anyone** — Home Assistant installs the version in `manifest.json`, not the latest. But this PR deliberately **does not bump the integration version**, so it does not ship on its own.

## Why bump the pin but not release

Neither bug in 1.4.4 affects Home Assistant:

- **The retry bug** only fired when the caller did not supply a session. HA passes `async_get_clientsession(hass)`, so it took the other branch and never hit it.
- **The `close()` bug** is latent — nothing in this integration calls `close()`, and `SmartCocoonManager` exposes no path to it.

An HA user upgrading would observe **zero difference**. That is not worth an update cycle, which is what makes this different from v1.3.3 — there the credential leak was actively affecting users and the release was urgent.

## Why bump it at all, then

- **`main` stays honest** — CI tests against the version the manifest declares.
- **The pin cannot quietly drift.** `requirements.txt` and `manifest.json` disagreed (1.4.1 vs 1.4.2) before #397, which meant local test runs resolved a different library than HA installed. Keeping both current is how that stays fixed.
- **Defense in depth** — if a `close()` call is ever added to this integration, the fixed library is already pinned and it will not take down HA's shared session.

It ships with whatever the next release turns out to be.

| File | From | To |
|---|---|---|
| `manifest.json` requirements | `1.4.3` | `1.4.4` |
| `requirements.txt` | `1.4.3` | `1.4.4` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)