### PR TITLE
ci: isolate the schedule so it cannot take pull request CI with it

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,30 @@
+---
+name: Nightly
+
+# This file exists to hold the schedule, and nothing else.
+#
+# GitHub disables scheduled workflows after 60 days of repository inactivity.
+# When that trigger lived in tests.yaml, being disabled took the entire
+# pull request pipeline with it -- silently, since a disabled workflow
+# reports no status at all rather than a failure. That went unnoticed from
+# 2026-05-27 for ten weeks.
+#
+# Keeping the schedule isolated here means the blast radius of the same thing
+# happening again is one nightly re-run, not every check on every PR.
+#
+# The nightly run is still worth having: pip-audit resolves against an
+# advisory database that moves, and semgrep against rule packs that move, so
+# it catches code becoming vulnerable without changing.
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  full-ci:
+    name: Full CI
+    uses: ./.github/workflows/tests.yaml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,14 +1,23 @@
 ---
 name: CI/CD Pipeline
 
+# Deliberately no `schedule:` trigger here. GitHub disables scheduled
+# workflows after 60 days of repository inactivity, and that is exactly what
+# happened to this file: CI was silently switched off on 2026-05-27 and
+# nobody noticed for ten weeks, because a disabled workflow reports nothing
+# rather than failing. Pull requests merged against checks that were months
+# stale.
+#
+# The nightly run still exists -- nightly.yml holds the schedule and calls
+# this workflow. If that one gets disabled the same way, the loss is a
+# nightly re-scan rather than all pull request validation.
 on:
   push:
     branches:
       - main
       - develop
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
+  workflow_call:
 
 env:
   DEFAULT_PYTHON: "3.13"


### PR DESCRIPTION
## The root cause of this whole session

GitHub disables scheduled workflows after **60 days of repository inactivity**. That is what happened here: CI was switched off on **2026-05-27** and went unnoticed for **ten weeks**.

The reason nobody noticed is the important part — **a disabled workflow reports no status at all.** Nothing turns red. Pull requests just quietly stop being checked, and the last green result stays visible next to them.

In that window:

- Nine dependabot PRs sat showing green checks that were 4–8 months old
- The labeler failed on every PR (invalid `head-branch` syntax)
- A `semgrep`/`homeassistant` dependency solve became unsatisfiable
- Credentials were being written to debug logs in plaintext

None of it was reachable until CI ran again.

## The fix

Move the schedule into `nightly.yml`, which does nothing but call this workflow. `tests.yaml` now triggers on `push`, `pull_request` and `workflow_call` only — **so it can never be auto-disabled.**

## Why not just delete the nightly run

It earns its place: `pip-audit` resolves against an advisory database that **moves**, and semgrep against rule packs that **move**. So the nightly run catches code becoming vulnerable *without changing* — which no push- or PR-triggered run can do.

The point is not to avoid ever being disabled. It is to make the consequence proportionate: if `nightly.yml` gets disabled by the same rule, the loss is **one nightly re-scan**, not every check on every pull request.

## Verifying it worked

`tests.yaml` keeps reporting the same check names, so branch protection needs no change. The nightly run appears as `Nightly / Full CI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)