### PR TITLE
Release v1.3.4

### DIFF
--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["pysmartcocoon"],
   "requirements": ["pysmartcocoon==1.4.4"],
-  "version": "1.3.3"
+  "version": "1.3.4"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name        = "hacs_smartcocoon"
-version     = "v1.3.3"
+version     = "v1.3.4"
 license     = {text = "MIT"}
 description = "SmartCocoon integration with Home Assistant."
 readme      = "README.md"


### PR DESCRIPTION
Brings the published release in line with `main`, which has been carrying `pysmartcocoon==1.4.4` and a batch of CI work since v1.3.3.

## What users get

`pysmartcocoon` **1.4.3 → 1.4.4**:

- Retries now actually retry. The library closed its HTTP session inside the retry loop, so attempts after the first ran against a closed session and every transient rate-limit, server error or timeout became an immediate failure.
- `close()` no longer closes a session it does not own.

Both are real fixes, though **neither was reachable from Home Assistant** — HA supplies its own session, which is the path the retry bug missed, and nothing here calls `close()`. Expect no behavioural difference; this release exists so published matches `main`.

## Everything else is maintenance

CI and tooling only, invisible to users:

- The `schedule:` trigger moved out of the CI workflow, so GitHub's 60-day inactivity rule can no longer disable pull request validation (it did exactly that on 2026-05-27, unnoticed for ten weeks)
- prettier moved off `pre-commit/mirrors-prettier`, archived upstream on a `4.0.0-alpha` tag
- mypy 2, ruff 0.16.1, pylint 4.0.6 — each bumped in both places they are pinned
- Dependency backlog cleared; unmergeable bumps closed with reasons
- Black leftovers removed (`make format` was still invoking a tool CI does not run)

## Versions

| File | To |
|---|---|
| `manifest.json` version | `1.3.4` |
| `pyproject.toml` version | `v1.3.4` |
| `manifest.json` requirements | `pysmartcocoon==1.4.4` |
| `requirements.txt` | `pysmartcocoon==1.4.4` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)