### PR TITLE
Release v1.3.5: surface fan commands the API rejected

### DIFF
--- a/custom_components/smartcocoon/fan.py
+++ b/custom_components/smartcocoon/fan.py
@@ -11,6 +11,7 @@ from pysmartcocoon.manager import SmartCocoonManager
 from homeassistant.components.fan import ENTITY_ID_FORMAT, FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import async_generate_entity_id
 
@@ -404,6 +405,21 @@ class SmartCocoonFan(FanEntity):  # type: ignore[misc]
             pass
         super().async_write_ha_state()
 
+    def _raise_if_rejected(self, accepted: bool, action: str) -> None:
+        """Fail loudly when the fan did not accept a command.
+
+        The library reports whether the cloud API applied a change. Without
+        this the integration wrote the new state and logged success either
+        way, so a rejected command left Home Assistant showing a speed or
+        mode the vent never adopted -- with nothing for the user to act on.
+        """
+        if not accepted:
+            raise HomeAssistantError(
+                f"SmartCocoon did not apply the request to {action} for fan "
+                f"{self._fan_id}. The fan may be offline or the service may "
+                f"have rejected the change."
+            )
+
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
         _LOGGER.debug(
@@ -414,11 +430,12 @@ class SmartCocoonFan(FanEntity):  # type: ignore[misc]
         )
         assert self._scmanager is not None  # Checked in constructor
         scmanager = self._scmanager  # Store reference to avoid mypy issues
-        await self._smartcocoon.error_handler.async_retry_operation(
+        accepted = await self._smartcocoon.error_handler.async_retry_operation(
             operation=lambda: scmanager.async_set_fan_speed(self._fan_id, percentage),
             operation_name=f"set fan speed to {percentage}%",
             context={"fan_id": self._fan_id, "percentage": percentage},
         )
+        self._raise_if_rejected(accepted, f"set speed to {percentage}%")
         _LOGGER.debug(
             "Fan %s: Successfully set percentage to %s", self._fan_id, percentage
         )
@@ -435,18 +452,20 @@ class SmartCocoonFan(FanEntity):  # type: ignore[misc]
         assert self._scmanager is not None  # Checked in constructor
         scmanager = self._scmanager  # Store reference to avoid mypy issues
         if preset_mode == SC_PRESET_MODE_AUTO:
-            await self._smartcocoon.error_handler.async_retry_operation(
+            accepted = await self._smartcocoon.error_handler.async_retry_operation(
                 operation=lambda: scmanager.async_set_fan_auto(self._fan_id),
                 operation_name="set fan to auto mode",
                 context={"fan_id": self._fan_id, "preset_mode": preset_mode},
             )
+            self._raise_if_rejected(accepted, "set auto mode")
             _LOGGER.debug("Fan %s: Successfully set to auto mode", self._fan_id)
         elif preset_mode == SC_PRESET_MODE_ECO:
-            await self._smartcocoon.error_handler.async_retry_operation(
+            accepted = await self._smartcocoon.error_handler.async_retry_operation(
                 operation=lambda: scmanager.async_set_fan_eco(self._fan_id),
                 operation_name="set fan to eco mode",
                 context={"fan_id": self._fan_id, "preset_mode": preset_mode},
             )
+            self._raise_if_rejected(accepted, "set eco mode")
             _LOGGER.debug("Fan %s: Successfully set to eco mode", self._fan_id)
         else:
             raise ValueError(f"Unsupported preset mode {preset_mode}")
@@ -458,11 +477,12 @@ class SmartCocoonFan(FanEntity):  # type: ignore[misc]
         _LOGGER.debug("Fan %s: Turning off", self._fan_id)
         assert self._scmanager is not None  # Checked in constructor
         scmanager = self._scmanager  # Store reference to avoid mypy issues
-        await self._smartcocoon.error_handler.async_retry_operation(
+        accepted = await self._smartcocoon.error_handler.async_retry_operation(
             operation=lambda: scmanager.async_fan_turn_off(self._fan_id),
             operation_name="turn off fan",
             context={"fan_id": self._fan_id},
         )
+        self._raise_if_rejected(accepted, "turn off")
         _LOGGER.debug("Fan %s: Successfully turned off", self._fan_id)
         self.async_write_ha_state()
 
@@ -488,10 +508,11 @@ class SmartCocoonFan(FanEntity):  # type: ignore[misc]
 
         assert self._scmanager is not None  # Checked in constructor
         scmanager = self._scmanager  # Store reference to avoid mypy issues
-        await self._smartcocoon.error_handler.async_retry_operation(
+        accepted = await self._smartcocoon.error_handler.async_retry_operation(
             operation=lambda: scmanager.async_fan_turn_on(self._fan_id),
             operation_name="turn on fan",
             context={"fan_id": self._fan_id},
         )
+        self._raise_if_rejected(accepted, "turn on")
         _LOGGER.debug("Fan %s: Successfully turned on", self._fan_id)
         self.async_write_ha_state()

--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["pysmartcocoon"],
-  "requirements": ["pysmartcocoon==1.4.4"],
-  "version": "1.3.4"
+  "requirements": ["pysmartcocoon==1.4.5"],
+  "version": "1.3.5"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name        = "hacs_smartcocoon"
-version     = "v1.3.4"
+version     = "v1.3.5"
 license     = {text = "MIT"}
 description = "SmartCocoon integration with Home Assistant."
 readme      = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pysmartcocoon==1.4.4
+pysmartcocoon==1.4.5

--- a/tests/test_rejected_commands.py
+++ b/tests/test_rejected_commands.py
@@ -1,0 +1,108 @@
+"""Tests that a rejected fan command surfaces as an error in Home Assistant.
+
+The library reports whether the cloud API actually applied a change. Before
+this, the integration wrote the new state and logged success either way, so a
+rejected command left Home Assistant displaying a speed or mode the vent had
+never adopted, with nothing for the user to act on.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.smartcocoon.fan import SmartCocoonFan
+from homeassistant.exceptions import HomeAssistantError
+
+FAN_ID = "abc123"
+
+
+def _fan_entity(accepted: bool) -> SmartCocoonFan:
+    """Build a fan entity whose commands return `accepted`."""
+    entity = SmartCocoonFan.__new__(SmartCocoonFan)
+
+    scmanager = MagicMock()
+    for name in (
+        "async_set_fan_speed",
+        "async_fan_turn_on",
+        "async_fan_turn_off",
+        "async_set_fan_auto",
+        "async_set_fan_eco",
+    ):
+        setattr(scmanager, name, AsyncMock(return_value=accepted))
+
+    controller = MagicMock()
+
+    # The real error handler awaits the operation and returns its result. A
+    # non-async lambda here would hand back an un-awaited coroutine, which is
+    # truthy and would make every one of these tests pass vacuously.
+    async def _run(operation: object, **_: object) -> object:
+        return await operation()  # type: ignore[operator]
+
+    controller.error_handler.async_retry_operation = AsyncMock(side_effect=_run)
+
+    # Built via __new__ to avoid the full Home Assistant entity setup, so the
+    # collaborators have to be injected directly.
+    entity._fan_id = FAN_ID  # noqa: SLF001
+    entity._scmanager = scmanager  # noqa: SLF001
+    entity._smartcocoon = controller  # noqa: SLF001
+    entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+    return entity
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("method", "args"),
+    [
+        ("async_set_percentage", (50,)),
+        ("async_turn_on", ()),
+        ("async_turn_off", ()),
+    ],
+)
+async def test_rejected_command_raises(method: str, args: tuple[object, ...]) -> None:
+    """A command the fan did not accept must raise, not report success."""
+    entity = _fan_entity(accepted=False)
+
+    with pytest.raises(HomeAssistantError):
+        await getattr(entity, method)(*args)
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("method", "args"),
+    [
+        ("async_set_percentage", (50,)),
+        ("async_turn_on", ()),
+        ("async_turn_off", ()),
+    ],
+)
+async def test_accepted_command_succeeds(method: str, args: tuple[object, ...]) -> None:
+    """An accepted command still completes and writes state."""
+    entity = _fan_entity(accepted=True)
+
+    await getattr(entity, method)(*args)
+
+    assert entity.async_write_ha_state.call_count > 0  # type: ignore[attr-defined]
+
+
+async def test_rejected_command_does_not_write_state() -> None:
+    """State must not be written for a change that was not applied.
+
+    This is the point of the fix: writing state on a rejected command is
+    what left the UI disagreeing with the hardware.
+    """
+    entity = _fan_entity(accepted=False)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_percentage(50)
+
+    assert entity.async_write_ha_state.call_count == 0  # type: ignore[attr-defined]
+
+
+async def test_error_message_identifies_the_fan_and_action() -> None:
+    """The raised error should say which fan and what was attempted."""
+    entity = _fan_entity(accepted=False)
+
+    with pytest.raises(HomeAssistantError) as excinfo:
+        await entity.async_set_percentage(75)
+
+    message = str(excinfo.value)
+    assert FAN_ID in message
+    assert "75" in message

--- a/tests/test_rejected_commands.py
+++ b/tests/test_rejected_commands.py
@@ -16,37 +16,49 @@ from homeassistant.exceptions import HomeAssistantError
 FAN_ID = "abc123"
 
 
-def _fan_entity(accepted: bool) -> SmartCocoonFan:
+class _StubFan(SmartCocoonFan):
+    """A fan entity wired to stubs, keeping the real command methods.
+
+    Subclassing rather than patching a constructed entity avoids the full
+    Home Assistant entity setup while leaving the code under test untouched.
+    """
+
+    # The parent __init__ needs a config entry, hass and a live manager, none
+    # of which these tests want.
+    def __init__(self, accepted: bool) -> None:  # pylint: disable=super-init-not-called
+        scmanager = MagicMock()
+        for name in (
+            "async_set_fan_speed",
+            "async_fan_turn_on",
+            "async_fan_turn_off",
+            "async_set_fan_auto",
+            "async_set_fan_eco",
+        ):
+            setattr(scmanager, name, AsyncMock(return_value=accepted))
+
+        controller = MagicMock()
+
+        # The real error handler awaits the operation and returns its result.
+        # A non-async lambda here would hand back an un-awaited coroutine,
+        # which is truthy -- every one of these tests would pass vacuously.
+        async def _run(operation: object, **_: object) -> object:
+            return await operation()  # type: ignore[operator]
+
+        controller.error_handler.async_retry_operation = AsyncMock(side_effect=_run)
+
+        self._fan_id = FAN_ID
+        self._scmanager = scmanager
+        self._smartcocoon = controller
+        self.state_writes = 0
+
+    def async_write_ha_state(self) -> None:
+        """Record state writes instead of touching Home Assistant."""
+        self.state_writes += 1
+
+
+def _fan_entity(accepted: bool) -> _StubFan:
     """Build a fan entity whose commands return `accepted`."""
-    entity = SmartCocoonFan.__new__(SmartCocoonFan)
-
-    scmanager = MagicMock()
-    for name in (
-        "async_set_fan_speed",
-        "async_fan_turn_on",
-        "async_fan_turn_off",
-        "async_set_fan_auto",
-        "async_set_fan_eco",
-    ):
-        setattr(scmanager, name, AsyncMock(return_value=accepted))
-
-    controller = MagicMock()
-
-    # The real error handler awaits the operation and returns its result. A
-    # non-async lambda here would hand back an un-awaited coroutine, which is
-    # truthy and would make every one of these tests pass vacuously.
-    async def _run(operation: object, **_: object) -> object:
-        return await operation()  # type: ignore[operator]
-
-    controller.error_handler.async_retry_operation = AsyncMock(side_effect=_run)
-
-    # Built via __new__ to avoid the full Home Assistant entity setup, so the
-    # collaborators have to be injected directly.
-    entity._fan_id = FAN_ID  # noqa: SLF001
-    entity._scmanager = scmanager  # noqa: SLF001
-    entity._smartcocoon = controller  # noqa: SLF001
-    entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
-    return entity
+    return _StubFan(accepted)
 
 
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
@@ -79,7 +91,7 @@ async def test_accepted_command_succeeds(method: str, args: tuple[object, ...]) 
 
     await getattr(entity, method)(*args)
 
-    assert entity.async_write_ha_state.call_count > 0  # type: ignore[attr-defined]
+    assert entity.state_writes > 0
 
 
 async def test_rejected_command_does_not_write_state() -> None:
@@ -93,7 +105,7 @@ async def test_rejected_command_does_not_write_state() -> None:
     with pytest.raises(HomeAssistantError):
         await entity.async_set_percentage(50)
 
-    assert entity.async_write_ha_state.call_count == 0  # type: ignore[attr-defined]
+    assert entity.state_writes == 0
 
 
 async def test_error_message_identifies_the_fan_and_action() -> None:


### PR DESCRIPTION
## The problem

`pysmartcocoon` 1.4.5 reports whether the cloud API actually applied a change. This integration **ignored that**, wrote the new state regardless, and logged success:

```python
await ...async_retry_operation(...)   # result discarded
_LOGGER.debug("Fan %s: Successfully set percentage to %s", ...)
self.async_write_ha_state()           # writes a state that may be fiction
```

So a rejected command left Home Assistant showing a speed or mode the vent had **never adopted**, with no error and nothing to retry. Worse than a visible failure — the UI actively contradicts the hardware, and the user has no reason to look.

## The fix

Raise `HomeAssistantError` when a command is not accepted, on **every** control path:

| Path | Covered |
|---|---|
| `async_set_percentage` | ✅ |
| `async_turn_on` | ✅ |
| `async_turn_off` | ✅ |
| `async_set_preset_mode` — auto | ✅ |
| `async_set_preset_mode` — eco | ✅ |

State is no longer written for a change that did not happen. The error names the fan and the attempted action, so it is actionable in the UI rather than just red.

## Versions

| File | To |
|---|---|
| `manifest.json` requirements | `pysmartcocoon==1.4.5` |
| `requirements.txt` | `pysmartcocoon==1.4.5` |
| `manifest.json` version | `1.3.5` |
| `pyproject.toml` version | `v1.3.5` |

## Tests

8 new tests, run against **Home Assistant 2026.2.3 on Python 3.13** locally, not just left to CI.

They are regression tests — **5 of 8 fail against the unfixed integration**. That check mattered here: my first version of the mock returned an un-awaited coroutine, which is truthy, so every test passed while asserting nothing. Running them against the old code is what exposed it.

Includes `test_rejected_command_does_not_write_state`, which pins the specific behaviour that caused the bug.

## User-visible change

Commands that silently did nothing will now raise a visible error. That is the point, but it is a change in behaviour: users with a flaky or offline fan will start seeing errors where they previously saw a wrong state. The wrong state was the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)