### PR TITLE
fix: use aware UTC in the connection monitor, and fix its config units

### DIFF
--- a/custom_components/smartcocoon/__init__.py
+++ b/custom_components/smartcocoon/__init__.py
@@ -119,16 +119,14 @@ class SmartCocoonController:
         _LOGGER.debug("scmanager.fans: %s", self._scmanager.fans)
 
         # Start connection monitoring
+        # Passed in the units the options flow collects; ConnectionMonitorConfig
+        # converts to seconds itself.
         config = ConnectionMonitorConfig(
-            max_offline_duration=self._max_offline_duration
-            * 3600,  # Convert hours to seconds
-            recovery_attempt_interval=self._recovery_attempt_interval
-            * 60,  # Convert minutes to seconds
+            max_offline_hours=self._max_offline_duration,
+            recovery_attempt_minutes=self._recovery_attempt_interval,
             max_recovery_attempts_per_hour=self._max_recovery_attempts_per_hour,
-            recovery_reset_interval=self._recovery_reset_interval
-            * 60,  # Convert minutes to seconds
-            connection_check_interval=self._connection_check_interval
-            * 3600,  # Convert hours to seconds
+            recovery_reset_minutes=self._recovery_reset_interval,
+            connection_check_hours=self._connection_check_interval,
         )
 
         self._connection_monitor = ConnectionMonitor(

--- a/custom_components/smartcocoon/connection_monitor.py
+++ b/custom_components/smartcocoon/connection_monitor.py
@@ -7,30 +7,53 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import async_call_later
+from homeassistant.util import dt as dt_util
 
+from .const import (
+    DEFAULT_CONNECTION_CHECK_INTERVAL,
+    DEFAULT_MAX_OFFLINE_DURATION,
+    DEFAULT_MAX_RECOVERY_ATTEMPTS_PER_HOUR,
+    DEFAULT_RECOVERY_ATTEMPT_INTERVAL,
+    DEFAULT_RECOVERY_RESET_INTERVAL,
+)
 from .error_handler import SmartCocoonErrorHandler
 
 _LOGGER = logging.getLogger(__name__)
 
+_SECONDS_PER_HOUR = 3600
+_SECONDS_PER_MINUTE = 60
+
 
 class ConnectionMonitorConfig:
-    """Configuration for ConnectionMonitor."""
+    """Configuration for ConnectionMonitor.
 
-    def __init__(self, **kwargs: int) -> None:
-        """Initialize config with keyword arguments."""
-        self.max_offline_duration = kwargs.get("max_offline_duration", 3600)  # 1 hour
-        self.recovery_attempt_interval = kwargs.get(
-            "recovery_attempt_interval", 300
-        )  # 5 minutes
-        self.max_recovery_attempts_per_hour = kwargs.get(
-            "max_recovery_attempts_per_hour", 5
-        )  # 5 attempts
-        self.recovery_reset_interval = kwargs.get(
-            "recovery_reset_interval", 3600
-        )  # 60 minutes
-        self.connection_check_interval = kwargs.get(
-            "connection_check_interval", 3600
-        )  # 1 hour
+    Takes the same units the options flow uses -- hours and minutes -- and
+    converts to seconds once, here. Previously the caller did the arithmetic
+    and this class defaulted to raw seconds, so the two default sets were not
+    comparable by eye: `24` here meant hours, `3600` meant seconds, and the
+    fallbacks did not describe the shipped configuration at all.
+
+    Parameter names carry their units for the same reason.
+    """
+
+    def __init__(
+        self,
+        max_offline_hours: int = DEFAULT_MAX_OFFLINE_DURATION,
+        recovery_attempt_minutes: int = DEFAULT_RECOVERY_ATTEMPT_INTERVAL,
+        max_recovery_attempts_per_hour: int = DEFAULT_MAX_RECOVERY_ATTEMPTS_PER_HOUR,
+        recovery_reset_minutes: int = DEFAULT_RECOVERY_RESET_INTERVAL,
+        connection_check_hours: int = DEFAULT_CONNECTION_CHECK_INTERVAL,
+    ) -> None:
+        """Initialise config, converting to the seconds used internally.
+
+        Named parameters rather than **kwargs: the previous signature
+        silently ignored a mistyped keyword and used the default instead.
+        """
+        self.max_offline_duration = max_offline_hours * _SECONDS_PER_HOUR
+        self.recovery_attempt_interval = recovery_attempt_minutes * _SECONDS_PER_MINUTE
+        self.max_recovery_attempts_per_hour = max_recovery_attempts_per_hour
+        self.recovery_reset_interval = recovery_reset_minutes * _SECONDS_PER_MINUTE
+        self.connection_check_interval = connection_check_hours * _SECONDS_PER_HOUR
 
 
 class ConnectionMonitor:
@@ -57,7 +80,7 @@ class ConnectionMonitor:
         self._device_states: dict[str, dict[str, Any]] = {}
         self._last_check: datetime | None = None
         self._unsubscribe_timer: Any = None
-        self._startup_time: datetime = datetime.now()
+        self._startup_time: datetime = dt_util.utcnow()
         self._grace_period_callback: Any = None
         self._recovery_callbacks: dict[str, Any] = {}
         self._periodic_check_callback: Any = None
@@ -138,7 +161,7 @@ class ConnectionMonitor:
             "Checking SmartCocoon device connections for %d fans",
             len(self._scmanager.fans),
         )
-        self._last_check = now or datetime.now()
+        self._last_check = now or dt_util.utcnow()
 
         # High-level visibility of which fans will be evaluated
         _LOGGER.debug(
@@ -152,7 +175,7 @@ class ConnectionMonitor:
 
     async def _check_device_connection(self, fan_id: str, fan: Any) -> None:
         """Check and potentially recover a specific device connection."""
-        current_time = datetime.now()
+        current_time = dt_util.utcnow()
         is_connected = getattr(fan, "connected", False)
 
         _LOGGER.debug(
@@ -316,7 +339,7 @@ class ConnectionMonitor:
         self, fan_id: str, fan: Any, device_state: dict[str, Any]
     ) -> None:
         """Attempt to recover a disconnected device."""
-        current_time = datetime.now()
+        current_time = dt_util.utcnow()
 
         # Don't attempt recovery too frequently
         if device_state["last_recovery_attempt"]:

--- a/tests/test_connection_monitor.py
+++ b/tests/test_connection_monitor.py
@@ -3,7 +3,7 @@
 
 # pylint: disable=protected-access,unused-argument
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -16,6 +16,7 @@ from custom_components.smartcocoon.error_handler import (
     RetryConfig,
     SmartCocoonErrorHandler,
 )
+from homeassistant.util import dt as dt_util
 
 
 class TestConnectionMonitor:
@@ -57,12 +58,17 @@ class TestConnectionMonitor:
     @pytest.fixture
     def connection_monitor(self, mock_hass, mock_scmanager, error_handler):
         """Create a ConnectionMonitor instance."""
+        # The shipped defaults. These previously read as seconds (3600 / 3600),
+        # which made max_offline equal to recovery_reset -- a combination that
+        # cannot occur in production and in which the reset branch of
+        # _attempt_device_recovery is unreachable, so these tests could never
+        # exercise it.
         config = ConnectionMonitorConfig(
-            max_offline_duration=3600,  # 1 hour for testing
-            recovery_attempt_interval=300,  # 5 minutes for testing
-            max_recovery_attempts_per_hour=5,  # 5 attempts for testing
-            recovery_reset_interval=3600,  # 60 minutes for testing
-            connection_check_interval=3600,  # 1 hour for testing
+            max_offline_hours=24,
+            recovery_attempt_minutes=5,
+            max_recovery_attempts_per_hour=5,
+            recovery_reset_minutes=60,
+            connection_check_hours=1,
         )
 
         return ConnectionMonitor(
@@ -149,7 +155,7 @@ class TestConnectionMonitor:
         # Initialize device state
         connection_monitor._device_states["fan1"] = {
             "last_connected": None,
-            "last_disconnected": datetime.now() - timedelta(seconds=120),
+            "last_disconnected": dt_util.utcnow() - timedelta(seconds=120),
             "recovery_attempts": 0,
             "first_recovery_attempt": None,
             "last_recovery_attempt": None,
@@ -177,7 +183,7 @@ class TestConnectionMonitor:
         # Initialize device state
         connection_monitor._device_states["fan1"] = {
             "last_connected": None,
-            "last_disconnected": datetime.now() - timedelta(seconds=120),
+            "last_disconnected": dt_util.utcnow() - timedelta(seconds=120),
             "recovery_attempts": 0,
             "first_recovery_attempt": None,
             "last_recovery_attempt": None,
@@ -204,10 +210,10 @@ class TestConnectionMonitor:
         # Initialize device state with recent recovery attempt
         connection_monitor._device_states["fan1"] = {
             "last_connected": None,
-            "last_disconnected": datetime.now() - timedelta(seconds=120),
+            "last_disconnected": dt_util.utcnow() - timedelta(seconds=120),
             "recovery_attempts": 1,
             "first_recovery_attempt": None,
-            "last_recovery_attempt": datetime.now()
+            "last_recovery_attempt": dt_util.utcnow()
             - timedelta(seconds=30),  # Recent attempt
         }
 
@@ -228,10 +234,10 @@ class TestConnectionMonitor:
         # Initialize device state with max attempts reached
         connection_monitor._device_states["fan1"] = {
             "last_connected": None,
-            "last_disconnected": datetime.now() - timedelta(seconds=120),
+            "last_disconnected": dt_util.utcnow() - timedelta(seconds=120),
             "recovery_attempts": 5,  # Max attempts
             "first_recovery_attempt": None,
-            "last_recovery_attempt": datetime.now()
+            "last_recovery_attempt": dt_util.utcnow()
             - timedelta(seconds=600),  # Old attempt
         }
 
@@ -252,11 +258,11 @@ class TestConnectionMonitor:
         # Initialize device state with long offline duration
         connection_monitor._device_states["fan1"] = {
             "last_connected": None,
-            "last_disconnected": datetime.now()
+            "last_disconnected": dt_util.utcnow()
             - timedelta(hours=25),  # 25 hours offline
             "recovery_attempts": 1,
             "first_recovery_attempt": None,
-            "last_recovery_attempt": datetime.now() - timedelta(hours=25),
+            "last_recovery_attempt": dt_util.utcnow() - timedelta(hours=25),
         }
 
         # Attempt recovery (should be blocked by max offline duration)
@@ -272,7 +278,7 @@ class TestConnectionMonitor:
         # Initialize some device states
         connection_monitor._device_states = {
             "fan1": {
-                "last_connected": datetime.now(),
+                "last_connected": dt_util.utcnow(),
                 "last_disconnected": None,
                 "recovery_attempts": 0,
                 "first_recovery_attempt": None,

--- a/tests/test_monitor_config.py
+++ b/tests/test_monitor_config.py
@@ -1,0 +1,145 @@
+"""Tests for ConnectionMonitorConfig units and time handling.
+
+Three things are pinned here:
+
+1. The config converts from the units the options flow collects (hours and
+   minutes) to the seconds used internally, in one place.
+2. Its defaults describe the shipped configuration. They previously read as
+   raw seconds and made `max_offline_duration` equal `recovery_reset_interval`,
+   a combination that cannot occur in production and in which the recovery
+   reset is unreachable.
+3. Timestamps are timezone-aware UTC, matching what Home Assistant hands to
+   `async_call_later` callbacks. Mixing the two raises TypeError.
+"""
+
+# pylint: disable=protected-access
+# ruff: noqa: SLF001
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.smartcocoon.connection_monitor import (
+    ConnectionMonitor,
+    ConnectionMonitorConfig,
+)
+from custom_components.smartcocoon.const import (
+    DEFAULT_MAX_OFFLINE_DURATION,
+    DEFAULT_RECOVERY_RESET_INTERVAL,
+)
+from custom_components.smartcocoon.error_handler import (
+    RetryConfig,
+    SmartCocoonErrorHandler,
+)
+from homeassistant.util import dt as dt_util
+
+
+def test_units_are_converted_to_seconds() -> None:
+    """Hours and minutes in, seconds out."""
+    config = ConnectionMonitorConfig(
+        max_offline_hours=2,
+        recovery_attempt_minutes=3,
+        recovery_reset_minutes=4,
+        connection_check_hours=5,
+    )
+
+    assert config.max_offline_duration == 2 * 3600
+    assert config.recovery_attempt_interval == 3 * 60
+    assert config.recovery_reset_interval == 4 * 60
+    assert config.connection_check_interval == 5 * 3600
+
+
+def test_defaults_match_the_shipped_configuration() -> None:
+    """Constructing bare must give what the integration actually runs."""
+    config = ConnectionMonitorConfig()
+
+    assert config.max_offline_duration == DEFAULT_MAX_OFFLINE_DURATION * 3600
+    assert config.recovery_reset_interval == DEFAULT_RECOVERY_RESET_INTERVAL * 60
+
+
+def test_reset_interval_is_shorter_than_max_offline() -> None:
+    """The recovery reset must be reachable before recovery gives up.
+
+    `_attempt_device_recovery` returns early once a fan has been offline
+    longer than `max_offline_duration`, and the reset check sits after that
+    return. If the two are equal -- as the old defaults made them -- the
+    reset can never run, because `first_recovery_attempt` always postdates
+    `last_disconnected`.
+    """
+    config = ConnectionMonitorConfig()
+
+    assert config.recovery_reset_interval < config.max_offline_duration
+
+
+def _monitor() -> ConnectionMonitor:
+    scmanager = MagicMock()
+    scmanager.fans = {}
+    return ConnectionMonitor(
+        hass=MagicMock(),
+        scmanager=scmanager,
+        error_handler=SmartCocoonErrorHandler(RetryConfig(max_attempts=1)),
+        config=ConnectionMonitorConfig(),
+    )
+
+
+async def test_recovery_attempts_reset_after_the_interval() -> None:
+    """The branch that was unreachable under the old defaults.
+
+    A fan offline for two hours, whose first recovery attempt was 90 minutes
+    ago, is past the 60 minute reset but well inside the 24 hour give-up
+    window -- so the counter should be cleared and recovery continue.
+    """
+    monitor = _monitor()
+    now = dt_util.utcnow()
+
+    fan = MagicMock()
+    fan.connected = False
+    fan._async_update_fan = AsyncMock()
+
+    state = {
+        "last_connected": None,
+        "last_disconnected": now - timedelta(hours=2),
+        "recovery_attempts": 3,
+        "first_recovery_attempt": now - timedelta(minutes=90),
+        "last_recovery_attempt": now - timedelta(minutes=30),
+    }
+
+    await monitor._attempt_device_recovery("fan1", fan, state)
+
+    # Counter was reset, then this attempt counted as the first of the period.
+    assert state["recovery_attempts"] == 1
+    fan._async_update_fan.assert_called_once()
+
+
+async def test_recovery_stops_after_max_offline() -> None:
+    """Past the give-up window, no further attempts are made."""
+    monitor = _monitor()
+    now = dt_util.utcnow()
+
+    fan = MagicMock()
+    fan.connected = False
+    fan._async_update_fan = AsyncMock()
+
+    state = {
+        "last_connected": None,
+        "last_disconnected": now - timedelta(hours=25),
+        "recovery_attempts": 1,
+        "first_recovery_attempt": now - timedelta(hours=25),
+        "last_recovery_attempt": now - timedelta(hours=1),
+    }
+
+    await monitor._attempt_device_recovery("fan1", fan, state)
+
+    fan._async_update_fan.assert_not_called()
+
+
+def test_timestamps_are_timezone_aware() -> None:
+    """Naive timestamps would raise when compared with a callback's `now`.
+
+    Home Assistant passes an aware UTC datetime to `async_call_later`
+    callbacks, so anything stored here has to be aware too.
+    """
+    monitor = _monitor()
+
+    assert monitor._startup_time.tzinfo is not None
+    # And subtracting a callback-style timestamp must not raise.
+    assert (dt_util.utcnow() - monitor._startup_time).total_seconds() >= 0


### PR DESCRIPTION
Three problems, all in the same place.

## 1. Naive local time vs Home Assistant's aware UTC

Timestamps came from `datetime.now()` — naive local — while Home Assistant hands `async_call_later` callbacks an **aware UTC** datetime:

```
dt_util.utcnow() -> 2026-08-07 22:30:37+00:00   tzinfo: UTC
datetime.now()   -> 2026-08-07 18:30:37         tzinfo: None
```

The arithmetic happened to stay naive-vs-naive, so nothing raised — but any path comparing a stored timestamp against a callback's `now` would hit `TypeError: can't subtract offset-naive and offset-aware datetimes`, and durations distort across a DST transition.

Everything now uses `dt_util.utcnow()`. **Converting the existing tests produced exactly that TypeError**, which is the failure this prevents.

## 2. `**kwargs` silently swallowed typos

```python
def __init__(self, **kwargs: int) -> None:
    self.max_offline_duration = kwargs.get("max_offline_duration", 3600)
```

`ConnectionMonitorConfig(max_offline=5)` set nothing and quietly used the default — no error, no warning. Named parameters now.

## 3. Units, and defaults that described nothing real

`const.py` holds **hours and minutes** (`24`, `60`); the config held raw **seconds** (`3600`), with the conversion at the call site. The two default sets were not comparable by eye — `3600` next to `24` looks like a discrepancy but wasn't.

Worse, the fallbacks made `max_offline_duration` **equal** `recovery_reset_interval`. Since `first_recovery_attempt` always postdates `last_disconnected`, the reset check — which sits *after* the give-up return — is then **provably unreachable**. The test fixture used those exact values, so that branch was never exercised.

The config now takes hours and minutes, with the unit in each parameter name, and converts once internally. Defaults come from `const.py`, so constructing it bare gives the shipped behaviour.

### Demonstrated

A fan offline two hours, first recovery attempt 90 minutes ago:

```
OLD defaults (1h/60m):  attempts=3  update_called=0  -> abandoned, reset unreachable
NEW defaults (24h/60m): attempts=1  update_called=1  -> reset fired, recovery continued
```

## Tests

6 new, plus the existing 11 updated to aware UTC and to the real defaults. `test_recovery_attempts_reset_after_the_interval` covers the branch that could not previously run.

87 tests pass. ruff, pylint, and mypy all clean — the last in the pre-commit hook's isolated environment, not the project venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)