### PR TITLE
fix(ci): stop dependabot bumping half of a dual pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,9 +47,20 @@ updates:
     # version, so bumping one on its own is unsatisfiable and the pull
     # request can never go green. They move when that package moves.
     # `homeassistant` was already listed here for the same reason.
+    #
+    # pylint, ruff and mypy are each pinned twice: here and as a `rev` in
+    # .pre-commit-config.yaml. pre-commit is what gates CI, so a bump to
+    # requirements_test.txt alone changes local behaviour and leaves CI on the
+    # old version. Dependabot cannot see the second half of the pin, so every
+    # proposal it makes for these is wrong -- and with auto-merge enabled a
+    # minor bump lands unattended. mypy 2.1.0 -> 2.3.0 did exactly that.
+    # Bump these by hand, in both files, in one commit.
     ignore:
       - dependency-name: "homeassistant"
       - dependency-name: "pytest"
       - dependency-name: "pytest-asyncio"
       - dependency-name: "pytest-cov"
       - dependency-name: "pytest-timeout"
+      - dependency-name: "pylint"
+      - dependency-name: "ruff"
+      - dependency-name: "mypy"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
         types: [python]
   # Type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: v2.3.0
     hooks:
       - id: mypy
         additional_dependencies: [types-requests, types-PyYAML]


### PR DESCRIPTION
## What happened

Dependabot bumped `mypy` 2.1.0 → 2.3.0 in `requirements_test.txt` and **auto-merged it**, leaving `.pre-commit-config.yaml` on `v2.1.0`.

Since pre-commit is what gates CI, local runs moved to 2.3.0 while CI stayed on 2.1.0 — the exact drift this repo already had with ruff (0.14.10 local vs v0.6.9 in CI), reintroduced automatically and without review.

## Why it will keep happening

`pylint`, `ruff` and `mypy` are each pinned **twice** — in `requirements_test.txt` and as a `rev` in `.pre-commit-config.yaml`. **Dependabot can only see one half**, so every proposal it makes for them is either wrong (creates drift) or inert (CI unaffected).

Auto-merge makes it worse: a minor bump lands unattended, so the drift arrives silently. That is a hole in the automation, not bad luck — it will recur for every future bump of these three.

## Fix

Add all three to dependabot's `ignore` list. They get bumped by hand, in both files, in one commit — as `ruff` and `pylint` were in #398 and `mypy` in #404.

Also brings `mirrors-mypy` to `v2.3.0` to close the drift that already landed.

## Verification

mypy 2.3.0 checked in an environment matching the hook's `additional_dependencies` (`types-requests`, `types-PyYAML`, **no homeassistant**) rather than the project venv: **17 files, clean**. ruff clean, 87 tests pass.

## Note

`pysmartcocoon` does not have this exposure — its `requirements_test.txt` entries are unpinned, so dependabot has nothing to bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)