### PR TITLE
Release v1.3.6

### DIFF
--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["pysmartcocoon"],
-  "requirements": ["pysmartcocoon==1.4.5"],
-  "version": "1.3.5"
+  "requirements": ["pysmartcocoon==1.4.6"],
+  "version": "1.3.6"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name        = "hacs_smartcocoon"
-version     = "v1.3.5"
+version     = "v1.3.6"
 license     = {text = "MIT"}
 description = "SmartCocoon integration with Home Assistant."
 readme      = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pysmartcocoon==1.4.5
+pysmartcocoon==1.4.6


### PR DESCRIPTION
Ships the connection-monitor fixes already on `main`, and picks up `pysmartcocoon` 1.4.6.

## Integration

- **Connection monitor now uses timezone-aware UTC.** It stored naive local timestamps while Home Assistant hands `async_call_later` callbacks aware UTC ones. Nothing raised only because every arithmetic path happened to compare naive-with-naive; any comparison against a callback's `now` would have thrown `TypeError`, and durations distorted across DST.
- **`ConnectionMonitorConfig` takes named parameters.** It previously took `**kwargs`, so a mistyped keyword was silently ignored and the default used instead.
- **Its defaults now match the shipped configuration** and units live in the parameter names. The old fallbacks made `max_offline_duration` equal `recovery_reset_interval`, which makes the recovery reset unreachable — and the test fixture used exactly those values, so that branch was never exercised.

## Library — pysmartcocoon 1.4.6

- **A malformed fan no longer blocks every other fan's update.** `async_update_fans` raised on the first unusable entry and abandoned the refresh, leaving every fan after it with stale data until a later poll happened to succeed.
- **Incomplete payloads are refused rather than half-applied**, so a fan keeps coherent previous values instead of a mixture.
- **`last_connection` may legitimately be absent** and no longer raises.

## User impact

Mostly invisible. The stale-data fix may resolve fans that intermittently stopped updating for no apparent reason. No configuration changes.

| File | To |
|---|---|
| `manifest.json` requirements | `pysmartcocoon==1.4.6` |
| `requirements.txt` | `pysmartcocoon==1.4.6` |
| `manifest.json` version | `1.3.6` |
| `pyproject.toml` version | `v1.3.6` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)