### PR TITLE
chore: declare the Home Assistant version actually tested

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "SmartCocoon",
   "render_readme": true,
-  "homeassistant": "2025.5.0",
+  "homeassistant": "2026.2.3",
   "hide_default_branch": false
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,10 @@
 -r requirements.txt
-homeassistant>=2025.5.0
+# pytest-homeassistant-custom-component pins homeassistant to an exact version
+# (currently 2026.2.3), so that is what CI actually tests against and what
+# hacs.json declares as the minimum. This floor only documents the intent --
+# the pin above decides. When bumping that, update hacs.json to match, or the
+# integration advertises support for a version nothing verifies.
+homeassistant>=2026.2.3
 pytest-homeassistant-custom-component==0.13.316
 pytest-asyncio==1.3.0
 pytest-cov==7.0.0


### PR DESCRIPTION
## The problem

`hacs.json` advertised a minimum of **2025.5.0**, but CI has never tested that version. `pytest-homeassistant-custom-component` pins `homeassistant` **exactly** — currently `2026.2.3` — so that is the only version anything runs against.

```
hacs.json minimum:  2025.5.0   <- advertised
CI tests against:   2026.2.3   <- reality
```

The declared floor was 15 months stale and entirely unverified. HACS would install the integration onto releases nothing had ever run against.

## Change

| | From | To |
|---|---|---|
| `hacs.json` `homeassistant` | `2025.5.0` | `2026.2.3` |
| `requirements_test.txt` | `homeassistant>=2025.5.0` | `homeassistant>=2026.2.3` |

The `requirements_test.txt` floor only documents intent — the `pytest-homeassistant-custom-component` pin is what actually decides. There is now a comment saying so, and that the two must move together.

## ⚠️ This narrows supported versions

HACS **blocks updates below the declared minimum**, so anyone still on a release older than 2026.2.3 stops receiving updates to this integration.

That is the honest position — those versions are untested and might already be broken — but it is a real reduction in support, not a no-op. Worth being deliberate about.

## Not related to 2026.8

The 2026.8 device-registry change (devices restricted to a single config entry) needs **nothing** here. Checked against every deprecated API in the [developer blog post](https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/):

- `DeviceEntry.config_entries` — not used
- `DeviceEntry.primary_config_entry` — not used
- `DeviceRegistry.async_get_device()` — not used
- `DeviceInfo["via_device"]` — not used
- `async_update_device(add_config_entry_id=…)` — not used

The only device-registry contact is a plain `DeviceInfo` in `fan.py`, already one device per config entry. `connection_monitor` uses the *entity* registry.

## Verification

Dependency resolution clean (exit 0), 87 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)