### PR TITLE
Release v1.3.7: require Home Assistant 2026.2.3

### DIFF
--- a/custom_components/smartcocoon/manifest.json
+++ b/custom_components/smartcocoon/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/davecpearce/hacs_smartcocoon/issues",
   "loggers": ["pysmartcocoon"],
   "requirements": ["pysmartcocoon==1.4.6"],
-  "version": "1.3.6"
+  "version": "1.3.7"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name        = "hacs_smartcocoon"
-version     = "v1.3.6"
+version     = "v1.3.7"
 license     = {text = "MIT"}
 description = "SmartCocoon integration with Home Assistant."
 readme      = "README.md"


### PR DESCRIPTION
Ships the version declaration from #414 deliberately, rather than letting a user-visible support change ride along silently with a later fix.

## The only change

`hacs.json` now declares a minimum of **2026.2.3**, replacing **2025.5.0**.

That old floor had never been tested. `pytest-homeassistant-custom-component` pins `homeassistant` exactly, so 2026.2.3 is the only version CI has ever run against — the advertised minimum was 15 months stale and entirely unverified.

## ⚠️ This narrows supported versions

HACS **blocks updates below the declared minimum**. Anyone on a Home Assistant release older than 2026.2.3 will stop receiving updates to this integration.

No code changed, so nothing newly *breaks* on older versions — but nothing ever verified they worked, and now the integration says so honestly instead of implying support it could not back.

## Not a 2026.8 change

Unrelated to Home Assistant 2026.8. That release restricts devices to a single config entry, and this integration needs nothing for it — it touches the device registry only through a plain `DeviceInfo`, uses no deprecated lookup, and never sets `via_device`.

| File | To |
|---|---|
| `manifest.json` version | `1.3.7` |
| `pyproject.toml` version | `v1.3.7` |
| `hacs.json` homeassistant | `2026.2.3` (from #414) |

Library pin unchanged at `pysmartcocoon==1.4.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)