### PR TITLE
Proposal: opt-in Room Climate Boost blueprint (cooling + heating) + automation docs + tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,13 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-yaml
+        # Blueprints use Home Assistant custom tags (!input); check those with
+        # --unsafe below (syntax-only) while keeping strict parsing everywhere else.
+        exclude: ^blueprints/.*\.ya?ml$
+      - id: check-yaml
+        name: check-yaml (blueprints, allow HA custom tags)
+        args: [--unsafe]
+        files: ^blueprints/.*\.ya?ml$
       - id: end-of-file-fixer
       - id: trailing-whitespace
   # Formatting handled by Ruff (ruff-format); Black removed to avoid conflicts

--- a/README.md
+++ b/README.md
@@ -122,6 +122,21 @@ If `entity_id` is omitted, the service operates on all fans.
 
 <!---->
 
+## Automations & Blueprints
+
+Out of the box the integration gives you a `fan.*` entity per fan. The
+[**Automations & Blueprints cookbook**](docs/AUTOMATIONS.md) turns that into useful
+control — from one-line recipes (boost a hot room, quiet overnight, all vents off when
+away) up to a full self-regulating **Room Climate Boost** blueprint that drives a room's
+booster fan off your thermostat's `hvac_action` and a room temperature sensor.
+
+Import the blueprint (works with any `climate` entity that reports `hvac_action`;
+developed and tested against Ecobee):
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fdavecpearce%2Fhacs_smartcocoon%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fsmartcocoon%2Froom_climate_boost.yaml)
+
+See [`docs/AUTOMATIONS.md`](docs/AUTOMATIONS.md) for the full walkthrough.
+
 ## Contributions are welcome!
 
 If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -126,9 +126,10 @@ If `entity_id` is omitted, the service operates on all fans.
 
 Out of the box the integration gives you a `fan.*` entity per fan. The
 [**Automations & Blueprints cookbook**](docs/AUTOMATIONS.md) turns that into useful
-control — from one-line recipes (boost a hot room, quiet overnight, all vents off when
-away) up to a full self-regulating **Room Climate Boost** blueprint that drives a room's
-booster fan off your thermostat's `hvac_action` and a room temperature sensor.
+control — from one-line recipes (boost a hot or cold room, quiet overnight, all vents off
+when away) up to a full self-regulating **Room Climate Boost** blueprint that drives a
+room's booster fan off your thermostat's `hvac_action` and a room temperature sensor,
+symmetrically for **cooling and heating**.
 
 Import the blueprint (works with any `climate` entity that reports `hvac_action`;
 developed and tested against Ecobee):

--- a/blueprints/automation/smartcocoon/room_climate_boost.yaml
+++ b/blueprints/automation/smartcocoon/room_climate_boost.yaml
@@ -2,7 +2,10 @@ blueprint:
   name: SmartCocoon Room Climate Boost
   description: >-
     Automatic, self-regulating booster-fan control for one room, driven by the
-    thermostat's hvac_action + a room-sensor delta vs. the cool setpoint.
+    thermostat's hvac_action + a room-sensor delta vs. the relevant setpoint.
+    Symmetric: the same tier ladder serves BOTH cooling and heating (a register
+    booster pulls warm supply air into a cold room just as it pulls cool air in
+    summer). Enable each direction independently.
 
     COMPATIBILITY: works with any `climate` entity that reports `hvac_action`
     plus setpoints (`temperature` and/or `target_temp_high`/`target_temp_low`)
@@ -10,35 +13,37 @@ blueprint:
     that the thermostat report `hvac_action` — some integrations only report the
     mode. Developed and tested against Ecobee.
 
-      * room >= boost_threshold over cool setpoint:
-          - actively cooling  -> boost_speed  (cold air in duct, max recovery)
-          - fan-only (blower)  -> circulate_speed  (neutral air, equalize; 0=off)
-      * actively cooling, within threshold, daytime -> assist_speed
-      * HVAC OFF + blower on + home + room warmer than the house -> EQUALIZE
-        (see below)
-      * otherwise (fan-only/idle/heating within range) -> baseline_speed
-      * heating: baseline whisper unless enable_heating_boost
+    "Demand" = how far the room is on the wrong side of the active setpoint:
+    room-minus-cool_setpoint while cooling, heat_setpoint-minus-room while
+    heating (positive = escalate).
+
+      * demand >= boost_threshold:
+          - actively heating/cooling -> boost_speed  (max recovery)
+          - fan-only (blower)        -> circulate_speed  (0 = off)
+      * actively heating/cooling, within threshold, daytime -> assist_speed
+      * blower on, no active demand, home -> EQUALIZE toward the house (see below)
+      * otherwise (idle / within range) -> baseline_speed
       * force_max boolean ON -> 100% override (bypasses EVERYTHING, incl. manual OFF)
 
-    HVAC-OFF EQUALIZER: when there is no cool setpoint (cooling mode off) but the
-    central blower is still circulating and you're home, there is nothing to
-    "chase" — so instead the fan equalizes the room toward the HOUSE's own
-    current temperature (thermostat current_temperature, or a chosen reference
-    sensor). Tiers on (room - house):
+    Set enable_cooling / enable_heating to manage only one direction.
+
+    HVAC-OFF EQUALIZER: when the central blower is circulating with no active
+    heating/cooling demand and you're home, the fan equalizes the room toward the
+    HOUSE's own current temperature (thermostat current_temperature, or a chosen
+    reference sensor), in EITHER direction. Tiers on |room - house|:
       >= 2.0C -> 100% | >= 1.0C -> 60% | >= 0.5C -> 33% | else baseline.
-    It can only move house-temperature air (can't cool below the house), and is
-    gated by the away flag + night suppression. Set enable_equalize off to
+    It can only move house-temperature air (can't push past the house temp), and
+    is gated by the away flag + night suppression. Set enable_equalize off to
     disable per room.
 
-    Fan-only (AC on but idle) uses the cool setpoint as the reference. Speed
-    control is PERCENTAGE-ONLY (the only reliable lever; preset_mode is never
-    used). Speeds are tunable percentage defaults — the SmartCocoon integration
-    exposes 0-100 continuous and the hardware rounds to its nearest physical
-    step. At night, the assist + circulate + equalize tiers collapse to baseline
-    for constant sleep noise (per-room: disable via enable_night_suppression =
-    false, e.g. a home office used late in the evening). Only an active-cooling
-    boost may exceed baseline at night. A manually-off fan is respected unless
-    Force manage.
+    Speed control is PERCENTAGE-ONLY (the only reliable lever; preset_mode is
+    never used). Speeds are tunable percentage defaults — the SmartCocoon
+    integration exposes 0-100 continuous and the hardware rounds to its nearest
+    physical step. At night, the assist + circulate + equalize tiers collapse to
+    baseline for constant sleep noise (per-room: disable via
+    enable_night_suppression = false, e.g. a home office used late in the
+    evening). Only an active heating/cooling boost may exceed baseline at night.
+    A manually-off fan is respected unless Force manage.
   domain: automation
   source_url: https://github.com/davecpearce/hacs_smartcocoon/blob/main/blueprints/automation/smartcocoon/room_climate_boost.yaml
   homeassistant:
@@ -99,8 +104,8 @@ blueprint:
           step: 1
           mode: box
     assist_speed:
-      name: Cooling assist speed (%, daytime only)
-      description: Gentle daytime nudge while actively cooling and within the boost threshold. Suppressed at night.
+      name: Assist speed (%, daytime only)
+      description: Gentle daytime nudge while actively heating/cooling and within the boost threshold. Suppressed at night.
       default: 17
       selector:
         number:
@@ -112,8 +117,8 @@ blueprint:
       name: Fan-only circulate speed (%, 0 = off)
       description: >-
         DEFAULT 60 (on). Runs this speed in fan-only mode when the room is
-        >= boost_threshold above setpoint — pulls cooler house air into a hot
-        spot (equalizer; can't cool below house temp). Set 0 to opt a room OUT.
+        >= boost_threshold on the wrong side of the setpoint — pulls
+        house air into a hot (or cold) spot. Set 0 to opt a room OUT.
         Suppressed at night.
       default: 60
       selector:
@@ -125,9 +130,9 @@ blueprint:
     boost_speed:
       name: Boost speed (%, 0 = off)
       description: >-
-        Turbo recovery while actively cooling and beyond the threshold. Applies
-        day and night. Set 0 to disable turbo for this room (it falls back to
-        assist/baseline even when far off target).
+        Turbo recovery while actively heating/cooling and beyond the threshold.
+        Applies day and night. Set 0 to disable turbo for this room (it falls
+        back to assist/baseline even when far off target).
       default: 100
       selector:
         number:
@@ -226,10 +231,24 @@ blueprint:
       selector:
         entity:
           domain: input_boolean
-    enable_heating_boost:
-      name: Apply boost to heating too
-      description: Default OFF (heating = baseline whisper). ON = boost when actively heating and >= threshold below the heat setpoint.
-      default: false
+    enable_cooling:
+      name: Manage during cooling
+      description: >-
+        Default ON. Run the boost / circulate / assist tiers when the thermostat
+        is cooling (or fan-only with the room above the cool setpoint). Turn OFF
+        to leave the fan at baseline during cooling.
+      default: true
+      selector:
+        boolean: {}
+    enable_heating:
+      name: Manage during heating
+      description: >-
+        Default ON. Mirror the cooling tiers for heating: boost / circulate /
+        assist when the thermostat is heating (or fan-only with the room below
+        the heat setpoint) — a register booster pulls warm supply air into a cold
+        room just as it pulls cool air in summer. Turn OFF to leave the fan at
+        baseline during heating.
+      default: true
       selector:
         boolean: {}
     force_manage:
@@ -287,7 +306,8 @@ variables:
   enable_equalize: !input enable_equalize
   equalize_reference_sensor: !input equalize_reference_sensor
   away_boolean: !input away_boolean
-  enable_heating_boost: !input enable_heating_boost
+  enable_cooling: !input enable_cooling
+  enable_heating: !input enable_heating
   force_manage: !input force_manage
   force_max_boolean: !input force_max_boolean
   speed_floor_entity: !input speed_floor_entity
@@ -315,45 +335,73 @@ variables:
     {% if hi is not none %}{{ hi }}
     {% elif states(thermostat) == 'cool' and s is not none %}{{ s }}
     {% else %}{{ none }}{% endif %}
-  # Cooling-side delta: how far the room is ABOVE the cool setpoint (positive = hot).
-  delta: >-
+  # Heat setpoint: target_temp_low (heat_cool/auto) else temperature (heat mode).
+  heat_sp: >-
+    {% set lo = state_attr(thermostat, 'target_temp_low') %}
+    {% set s = state_attr(thermostat, 'temperature') %}
+    {% if lo is not none %}{{ lo }}
+    {% elif states(thermostat) == 'heat' and s is not none %}{{ s }}
+    {% else %}{{ none }}{% endif %}
+  # Cooling-side demand: how far the room is ABOVE the cool setpoint (positive = too hot).
+  cool_demand: >-
     {% set room = states(room_sensor) | float(none) %}
     {% set c = cool_sp | float(none) %}
     {% if room is none or c is none %}{{ none }}{% else %}{{ room - c }}{% endif %}
-  # Heating-side delta (only used when enable_heating_boost): how far BELOW heat setpoint.
-  heat_delta: >-
+  # Heating-side demand: how far the room is BELOW the heat setpoint (positive = too cold).
+  heat_demand: >-
     {% set room = states(room_sensor) | float(none) %}
-    {% set lo = state_attr(thermostat, 'target_temp_low') %}
-    {% set s = state_attr(thermostat, 'temperature') %}
-    {% set h = (lo if lo is not none else (s if states(thermostat) == 'heat' else none)) | float(none) %}
+    {% set h = heat_sp | float(none) %}
     {% if room is none or h is none %}{{ none }}{% else %}{{ h - room }}{% endif %}
-  # Final target speed.
+  # Final target speed. Symmetric: the same boost/circulate/assist ladder serves
+  # cooling and heating -- only the setpoint side (and its enable toggle) differ.
   desired_speed: >-
     {% set act = state_attr(thermostat, 'hvac_action') %}
     {% set cooling = act == 'cooling' %}
     {% set heating = act == 'heating' %}
-    {% set blower_on = act in ['cooling', 'fan'] %}
+    {% set blower_on = act in ['cooling', 'heating', 'fan'] %}
     {% set pct = state_attr(booster_fan, 'percentage') | int(0) %}
-    {% set high_speed = boost_speed if cooling else circulate_speed %}
+    {# Pick the active service's demand + enable toggle. When only the blower is
+       running (fan-only), use whichever setpoint the room is on the wrong side of. #}
+    {% if cooling %}
+      {% set demand = cool_demand %}
+      {% set service_ok = enable_cooling %}
+    {% elif heating %}
+      {% set demand = heat_demand %}
+      {% set service_ok = enable_heating %}
+    {% else %}
+      {% set cool_ok = enable_cooling and (cool_sp is not none) and (cool_demand is not none) %}
+      {% set heat_ok = enable_heating and (heat_sp is not none) and (heat_demand is not none) %}
+      {% if cool_ok and (not heat_ok or (cool_demand >= heat_demand)) %}
+        {% set demand = cool_demand %}
+        {% set service_ok = true %}
+      {% elif heat_ok %}
+        {% set demand = heat_demand %}
+        {% set service_ok = true %}
+      {% else %}
+        {% set demand = none %}
+        {% set service_ok = false %}
+      {% endif %}
+    {% endif %}
+    {% set active = cooling or heating %}
+    {% set high_speed = boost_speed if active else circulate_speed %}
     {% set currently_high = high_speed > 0 and pct >= (high_speed - 4) %}
-    {% set want_high = (delta is not none) and blower_on and high_speed > 0
-                       and (delta > release_threshold if currently_high else delta >= boost_threshold) %}
-    {# HVAC-off equalizer: no cool setpoint, blower circulating, home, not night-suppressed #}
+    {% set want_high = service_ok and (demand is not none) and blower_on and high_speed > 0
+                       and (demand > release_threshold if currently_high else demand >= boost_threshold) %}
+    {# HVAC-off/idle equalizer: blower circulating with no active service demand ->
+       equalize toward the house temperature in EITHER direction (abs delta). #}
     {% set ref_sensor = equalize_reference_sensor %}
     {% set house = (states(ref_sensor) | float(none)) if ref_sensor not in [none, 'none', ''] else (state_attr(thermostat, 'current_temperature') | float(none)) %}
     {% set room2 = states(room_sensor) | float(none) %}
-    {% set eq_delta = (room2 - house) if (house is not none and room2 is not none) else none %}
-    {% set equalize_active = enable_equalize and (cool_sp is none) and blower_on and home_ok
+    {% set eq_delta = (room2 - house) | abs if (house is not none and room2 is not none) else none %}
+    {% set equalize_active = enable_equalize and blower_on and home_ok
                              and (not suppress_night) and (eq_delta is not none) %}
     {% if force_max %}
       100
-    {% elif heating and enable_heating_boost and boost_speed > 0 and heat_delta is not none and heat_delta >= boost_threshold %}
-      {{ boost_speed }}
-    {% elif want_high and cooling %}
+    {% elif want_high and active %}
       {{ boost_speed }}
     {% elif want_high and not suppress_night %}
       {{ circulate_speed }}
-    {% elif cooling and not suppress_night %}
+    {% elif service_ok and active and not suppress_night %}
       {{ assist_speed }}
     {% elif equalize_active and eq_delta >= 2.0 %}
       100

--- a/blueprints/automation/smartcocoon/room_climate_boost.yaml
+++ b/blueprints/automation/smartcocoon/room_climate_boost.yaml
@@ -1,0 +1,405 @@
+blueprint:
+  name: SmartCocoon Room Climate Boost
+  description: >-
+    Automatic, self-regulating booster-fan control for one room, driven by the
+    thermostat's hvac_action + a room-sensor delta vs. the cool setpoint.
+
+    COMPATIBILITY: works with any `climate` entity that reports `hvac_action`
+    plus setpoints (`temperature` and/or `target_temp_high`/`target_temp_low`)
+    and, for the equalizer, `current_temperature`. The one hard requirement is
+    that the thermostat report `hvac_action` — some integrations only report the
+    mode. Developed and tested against Ecobee.
+
+      * room >= boost_threshold over cool setpoint:
+          - actively cooling  -> boost_speed  (cold air in duct, max recovery)
+          - fan-only (blower)  -> circulate_speed  (neutral air, equalize; 0=off)
+      * actively cooling, within threshold, daytime -> assist_speed
+      * HVAC OFF + blower on + home + room warmer than the house -> EQUALIZE
+        (see below)
+      * otherwise (fan-only/idle/heating within range) -> baseline_speed
+      * heating: baseline whisper unless enable_heating_boost
+      * force_max boolean ON -> 100% override (bypasses EVERYTHING, incl. manual OFF)
+
+    HVAC-OFF EQUALIZER: when there is no cool setpoint (cooling mode off) but the
+    central blower is still circulating and you're home, there is nothing to
+    "chase" — so instead the fan equalizes the room toward the HOUSE's own
+    current temperature (thermostat current_temperature, or a chosen reference
+    sensor). Tiers on (room - house):
+      >= 2.0C -> 100% | >= 1.0C -> 60% | >= 0.5C -> 33% | else baseline.
+    It can only move house-temperature air (can't cool below the house), and is
+    gated by the away flag + night suppression. Set enable_equalize off to
+    disable per room.
+
+    Fan-only (AC on but idle) uses the cool setpoint as the reference. Speed
+    control is PERCENTAGE-ONLY (the only reliable lever; preset_mode is never
+    used). Speeds are tunable percentage defaults — the SmartCocoon integration
+    exposes 0-100 continuous and the hardware rounds to its nearest physical
+    step. At night, the assist + circulate + equalize tiers collapse to baseline
+    for constant sleep noise (per-room: disable via enable_night_suppression =
+    false, e.g. a home office used late in the evening). Only an active-cooling
+    boost may exceed baseline at night. A manually-off fan is respected unless
+    Force manage.
+  domain: automation
+  source_url: https://github.com/davecpearce/hacs_smartcocoon/blob/main/blueprints/automation/smartcocoon/room_climate_boost.yaml
+  homeassistant:
+    min_version: "2026.2.3"
+  input:
+    thermostat:
+      name: Thermostat
+      description: The central climate entity whose hvac_action/setpoints drive the logic. Must report hvac_action.
+      selector:
+        entity:
+          domain: climate
+    room_sensor:
+      name: Room temperature sensor
+      description: Accurate ambient sensor for this room.
+      selector:
+        entity:
+          domain: sensor
+          device_class: temperature
+    booster_fan:
+      name: SmartCocoon fan
+      description: The SmartCocoon fan entity serving this room.
+      selector:
+        entity:
+          domain: fan
+    boost_threshold:
+      name: Boost threshold (°C off setpoint)
+      description: >-
+        Escalate (boost or circulate) when the room is at least this far above
+        the cool setpoint — or, if "Apply boost to heating too" is enabled, this
+        far below the heat setpoint.
+      default: 1.0
+      selector:
+        number:
+          min: 0.2
+          max: 5
+          step: 0.1
+          mode: box
+    release_threshold:
+      name: Release threshold (°C from setpoint)
+      description: >-
+        Sticky release. Once elevated (boost/circulate), hold until the room is
+        within this of setpoint, then step down. Prevents rubber-banding.
+      default: 0.3
+      selector:
+        number:
+          min: 0.1
+          max: 3
+          step: 0.1
+          mode: box
+    baseline_speed:
+      name: Baseline / quiet speed (%)
+      description: Always-on whisper for fan-only/idle/heating. Default 8 = a low, quiet speed.
+      default: 8
+      selector:
+        number:
+          min: 5
+          max: 100
+          step: 1
+          mode: box
+    assist_speed:
+      name: Cooling assist speed (%, daytime only)
+      description: Gentle daytime nudge while actively cooling and within the boost threshold. Suppressed at night.
+      default: 17
+      selector:
+        number:
+          min: 5
+          max: 100
+          step: 1
+          mode: box
+    circulate_speed:
+      name: Fan-only circulate speed (%, 0 = off)
+      description: >-
+        DEFAULT 60 (on). Runs this speed in fan-only mode when the room is
+        >= boost_threshold above setpoint — pulls cooler house air into a hot
+        spot (equalizer; can't cool below house temp). Set 0 to opt a room OUT.
+        Suppressed at night.
+      default: 60
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: box
+    boost_speed:
+      name: Boost speed (%, 0 = off)
+      description: >-
+        Turbo recovery while actively cooling and beyond the threshold. Applies
+        day and night. Set 0 to disable turbo for this room (it falls back to
+        assist/baseline even when far off target).
+      default: 100
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: box
+    max_speed:
+      name: Max speed cap (%)
+      description: >-
+        Hard ceiling for this room's NORMAL automatic speed (equalizer / cooling
+        boost / circulate / assist). Default 100 = no cap. Lower it where full
+        speed is too loud (e.g. an office). The MAX override (force_max) still
+        goes to 100% regardless of this cap.
+      default: 100
+      selector:
+        number:
+          min: 8
+          max: 100
+          step: 1
+          mode: box
+    night_max_speed:
+      name: Night max speed cap (%)
+      description: >-
+        Extra ceiling that applies ONLY during the night window
+        (night_start..night_end). Default 100 = no night cap. Set LOW (e.g.
+        baseline 8) to stop a jarring nighttime BOOST from waking a bedroom — at
+        night the fan won't exceed this. Daytime is unaffected; the MAX override
+        still bypasses.
+      default: 100
+      selector:
+        number:
+          min: 8
+          max: 100
+          step: 1
+          mode: box
+    night_start:
+      name: Night start hour (24h)
+      default: 22
+      selector:
+        number:
+          min: 0
+          max: 23
+          step: 1
+          mode: box
+    night_end:
+      name: Night end hour (24h)
+      default: 8
+      selector:
+        number:
+          min: 0
+          max: 23
+          step: 1
+          mode: box
+    enable_night_suppression:
+      name: Enable night suppression
+      description: >-
+        Default ON. During the night window, collapse the assist / circulate /
+        equalize tiers to baseline for CONSTANT sleep noise (only active-cooling
+        boost may exceed baseline). Turn OFF for a non-bedroom (e.g. a home
+        office used late in the evening) so those tiers work 24/7.
+      default: true
+      selector:
+        boolean: {}
+    enable_equalize:
+      name: Enable HVAC-off equalizer
+      description: >-
+        Default ON. When cooling mode is OFF but the blower still circulates and
+        you're home, run the fan to equalize the room toward the HOUSE current
+        temperature: (room-house) >= 2.0C -> 100%, >= 1.0C -> 60%, >= 0.5C ->
+        33%, else baseline. Respects the away flag + night suppression.
+      default: true
+      selector:
+        boolean: {}
+    equalize_reference_sensor:
+      name: Equalizer reference sensor (cool source)
+      description: >-
+        Temperature sensor the HVAC-off equalizer treats as the COOL SOURCE the
+        room equalizes toward (typically a main-floor / central sensor). Leave
+        unset to fall back to the thermostat current_temperature — which can be
+        sensor-averaged and warmer than the real main floor, making the
+        equalizer under-react.
+      default:
+      selector:
+        entity:
+          domain: sensor
+          device_class: temperature
+    away_boolean:
+      name: Away flag (optional input_boolean)
+      description: >-
+        Optional. An input_boolean that is ON when you're AWAY for an extended
+        period. When ON, the HVAC-off equalizer PAUSES (no point equalizing an
+        empty house). OFF = home = equalize. Leave unset to always equalize when
+        AC is off.
+      default:
+      selector:
+        entity:
+          domain: input_boolean
+    enable_heating_boost:
+      name: Apply boost to heating too
+      description: Default OFF (heating = baseline whisper). ON = boost when actively heating and >= threshold below the heat setpoint.
+      default: false
+      selector:
+        boolean: {}
+    force_manage:
+      name: Force manage (ignore manual fan-off)
+      description: Default OFF. When OFF, a manually-off fan is left alone until turned back on. ON = always manage.
+      default: false
+      selector:
+        boolean: {}
+    force_max_boolean:
+      name: Force-MAX boolean (optional input_boolean)
+      description: >-
+        Optional global override. When this input_boolean is ON, force this fan
+        to 100%, short-circuiting ALL other logic (night suppression, equalizer,
+        cooling tiers) AND overriding even a manually-OFF fan ("MAX = everything
+        on"). Point every room's instance at the same helper for one whole-house
+        blast switch. NOTE: because it is optional it is NOT a trigger — a change
+        is picked up on the next re-evaluation (room/thermostat change or the
+        periodic tick, within ~10 min).
+      default:
+      selector:
+        entity:
+          domain: input_boolean
+    speed_floor_entity:
+      name: External speed floor (optional input_number)
+      description: >-
+        Optional. An input_number (0-100) whose value is treated as a MINIMUM
+        fan speed: final = max(computed speed, floor). Lets an external
+        automation (e.g. a sunrise pre-cool ramp) proactively raise the fan
+        WITHOUT fighting this blueprint — this stays the sole writer and can
+        still go higher (boost). Leave unset for no floor. NOTE: because it is
+        optional it is NOT a trigger — a change is picked up on the next
+        re-evaluation (within ~10 min).
+      default:
+      selector:
+        entity:
+          domain: input_number
+
+mode: single
+
+variables:
+  thermostat: !input thermostat
+  room_sensor: !input room_sensor
+  booster_fan: !input booster_fan
+  boost_threshold: !input boost_threshold
+  release_threshold: !input release_threshold
+  baseline_speed: !input baseline_speed
+  assist_speed: !input assist_speed
+  circulate_speed: !input circulate_speed
+  boost_speed: !input boost_speed
+  max_speed: !input max_speed
+  night_max_speed: !input night_max_speed
+  night_start: !input night_start
+  night_end: !input night_end
+  enable_night_suppression: !input enable_night_suppression
+  enable_equalize: !input enable_equalize
+  equalize_reference_sensor: !input equalize_reference_sensor
+  away_boolean: !input away_boolean
+  enable_heating_boost: !input enable_heating_boost
+  force_manage: !input force_manage
+  force_max_boolean: !input force_max_boolean
+  speed_floor_entity: !input speed_floor_entity
+  # External minimum-speed floor (0 if none set / unavailable).
+  speed_floor: >-
+    {% if speed_floor_entity not in [none, 'none', ''] %}{{ states(speed_floor_entity) | int(0) }}{% else %}0{% endif %}
+  is_night: >-
+    {{ now().hour >= night_start or now().hour < night_end }}
+  # Night suppression only applies when the per-room toggle is on.
+  suppress_night: >-
+    {{ is_night and enable_night_suppression }}
+  # Home check for the equalizer: away_boolean ON = away = pause. Unset = always home.
+  home_ok: >-
+    {% if away_boolean in [none, 'none', ''] %}true{% else %}{{ is_state(away_boolean, 'off') }}{% endif %}
+  # Global MAX override: when the force_max boolean is ON, blast to 100% over everything.
+  force_max: >-
+    {% if force_max_boolean in [none, 'none', ''] %}false{% else %}{{ is_state(force_max_boolean, 'on') }}{% endif %}
+  # Cool setpoint: target_temp_high (heat_cool/auto) else temperature (cool mode).
+  cool_sp: >-
+    {% set hi = state_attr(thermostat, 'target_temp_high') %}
+    {% set s = state_attr(thermostat, 'temperature') %}
+    {% if hi is not none %}{{ hi }}
+    {% elif states(thermostat) == 'cool' and s is not none %}{{ s }}
+    {% else %}{{ none }}{% endif %}
+  # Cooling-side delta: how far the room is ABOVE the cool setpoint (positive = hot).
+  delta: >-
+    {% set room = states(room_sensor) | float(none) %}
+    {% set c = cool_sp | float(none) %}
+    {% if room is none or c is none %}{{ none }}{% else %}{{ room - c }}{% endif %}
+  # Heating-side delta (only used when enable_heating_boost): how far BELOW heat setpoint.
+  heat_delta: >-
+    {% set room = states(room_sensor) | float(none) %}
+    {% set lo = state_attr(thermostat, 'target_temp_low') %}
+    {% set s = state_attr(thermostat, 'temperature') %}
+    {% set h = (lo if lo is not none else (s if states(thermostat) == 'heat' else none)) | float(none) %}
+    {% if room is none or h is none %}{{ none }}{% else %}{{ h - room }}{% endif %}
+  # Final target speed.
+  desired_speed: >-
+    {% set act = state_attr(thermostat, 'hvac_action') %}
+    {% set cooling = act == 'cooling' %}
+    {% set heating = act == 'heating' %}
+    {% set blower_on = act in ['cooling', 'fan'] %}
+    {% set pct = state_attr(booster_fan, 'percentage') | int(0) %}
+    {% set high_speed = boost_speed if cooling else circulate_speed %}
+    {% set currently_high = high_speed > 0 and pct >= (high_speed - 4) %}
+    {% set want_high = (delta is not none) and blower_on and high_speed > 0
+                       and (delta > release_threshold if currently_high else delta >= boost_threshold) %}
+    {# HVAC-off equalizer: no cool setpoint, blower circulating, home, not night-suppressed #}
+    {% set ref_sensor = equalize_reference_sensor %}
+    {% set house = (states(ref_sensor) | float(none)) if ref_sensor not in [none, 'none', ''] else (state_attr(thermostat, 'current_temperature') | float(none)) %}
+    {% set room2 = states(room_sensor) | float(none) %}
+    {% set eq_delta = (room2 - house) if (house is not none and room2 is not none) else none %}
+    {% set equalize_active = enable_equalize and (cool_sp is none) and blower_on and home_ok
+                             and (not suppress_night) and (eq_delta is not none) %}
+    {% if force_max %}
+      100
+    {% elif heating and enable_heating_boost and boost_speed > 0 and heat_delta is not none and heat_delta >= boost_threshold %}
+      {{ boost_speed }}
+    {% elif want_high and cooling %}
+      {{ boost_speed }}
+    {% elif want_high and not suppress_night %}
+      {{ circulate_speed }}
+    {% elif cooling and not suppress_night %}
+      {{ assist_speed }}
+    {% elif equalize_active and eq_delta >= 2.0 %}
+      100
+    {% elif equalize_active and eq_delta >= 1.0 %}
+      60
+    {% elif equalize_active and eq_delta >= 0.5 %}
+      33
+    {% else %}
+      {{ baseline_speed }}
+    {% endif %}
+  # Apply the external floor: never below it, but boost can still exceed it.
+  # Cap normal speed at max_speed + an extra night-only cap; the MAX override bypasses both.
+  final_speed: >-
+    {% if force_max %}100{% else %}{% set cap = [ max_speed, (night_max_speed if is_night else 100) ] | min %}{{ [ [ desired_speed | int(0), speed_floor ] | max, cap ] | min }}{% endif %}
+
+trigger:
+  - platform: state
+    entity_id: !input room_sensor
+  - platform: state
+    entity_id: !input thermostat
+    attribute: hvac_action
+  - platform: state
+    entity_id: !input thermostat
+    attribute: temperature
+  - platform: state
+    entity_id: !input thermostat
+    attribute: target_temp_high
+  - platform: state
+    entity_id: !input thermostat
+    attribute: target_temp_low
+  - platform: time_pattern
+    minutes: /10 # safety re-eval + night boundary rollover + optional-input pickup
+
+# Respect a manual OFF (baseline is always >0, so an off fan is a human signal).
+condition:
+  - condition: template
+    value_template: "{{ force_manage or force_max or not is_state(booster_fan, 'off') }}"
+
+action:
+  # Re-command only when current speed is more than one fan-step (>4%) off desired.
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: >-
+              {{ ((state_attr(booster_fan, 'percentage') | int(-1)) - final_speed) | abs > 4 }}
+        sequence:
+          - service: fan.set_percentage
+            target:
+              entity_id: !input booster_fan
+            data:
+              percentage: "{{ final_speed }}"
+    default: []

--- a/blueprints/automation/smartcocoon/room_climate_boost.yaml
+++ b/blueprints/automation/smartcocoon/room_climate_boost.yaml
@@ -264,9 +264,9 @@ blueprint:
         to 100%, short-circuiting ALL other logic (night suppression, equalizer,
         cooling tiers) AND overriding even a manually-OFF fan ("MAX = everything
         on"). Point every room's instance at the same helper for one whole-house
-        blast switch. NOTE: because it is optional it is NOT a trigger — a change
-        is picked up on the next re-evaluation (room/thermostat change or the
-        periodic tick, within ~10 min).
+        blast switch. Responds instantly on both edges (dedicated template
+        triggers), so a dashboard toggle / voice intent / scene blasts to 100 and
+        reclaims control the moment it is turned off.
       default:
       selector:
         entity:
@@ -417,7 +417,24 @@ variables:
   final_speed: >-
     {% if force_max %}100{% else %}{% set cap = [ max_speed, (night_max_speed if is_night else 100) ] | min %}{{ [ [ desired_speed | int(0), speed_floor ] | max, cap ] | min }}{% endif %}
 
+# Bind the optional MAX helper for the template triggers below. An OPTIONAL input
+# cannot be a state-trigger entity_id (an unset input fails to load), but it CAN be
+# referenced inside a template: unset -> renders to `none` -> template is always
+# false -> nothing tracked, never fires, blueprint still loads.
+trigger_variables:
+  force_max_entity: !input force_max_boolean
+
 trigger:
+  # Instant whole-house MAX, both edges (unset-safe; see trigger_variables above).
+  # A template trigger only fires on false->true, so we need one per edge: ON gives
+  # immediate 100; OFF immediately reclaims control (else the fan stays pinned at
+  # 100 until the next re-eval, up to the time_pattern interval).
+  - platform: template
+    value_template: >-
+      {{ force_max_entity not in [none, 'none', ''] and is_state(force_max_entity, 'on') }}
+  - platform: template
+    value_template: >-
+      {{ force_max_entity not in [none, 'none', ''] and is_state(force_max_entity, 'off') }}
   - platform: state
     entity_id: !input room_sensor
   - platform: state
@@ -433,7 +450,7 @@ trigger:
     entity_id: !input thermostat
     attribute: target_temp_low
   - platform: time_pattern
-    minutes: /10 # safety re-eval + night boundary rollover + optional-input pickup
+    minutes: /10 # safety re-eval + night boundary rollover + speed-floor pickup
 
 # Respect a manual OFF (baseline is always >0, so an off fan is a human signal).
 condition:

--- a/blueprints/automation/smartcocoon/room_climate_boost.yaml
+++ b/blueprints/automation/smartcocoon/room_climate_boost.yaml
@@ -300,11 +300,14 @@ variables:
   suppress_night: >-
     {{ is_night and enable_night_suppression }}
   # Home check for the equalizer: away_boolean ON = away = pause. Unset = always home.
+  # NB: emit a real boolean (Jinja true/false render to "True"/"False", which HA
+  # parses back to bool) -- a hardcoded lowercase "true"/"false" stays a truthy
+  # STRING and breaks `{% if %}` / condition logic when the input is unset.
   home_ok: >-
-    {% if away_boolean in [none, 'none', ''] %}true{% else %}{{ is_state(away_boolean, 'off') }}{% endif %}
+    {{ is_state(away_boolean, 'off') if away_boolean not in [none, 'none', ''] else true }}
   # Global MAX override: when the force_max boolean is ON, blast to 100% over everything.
   force_max: >-
-    {% if force_max_boolean in [none, 'none', ''] %}false{% else %}{{ is_state(force_max_boolean, 'on') }}{% endif %}
+    {{ is_state(force_max_boolean, 'on') if force_max_boolean not in [none, 'none', ''] else false }}
   # Cool setpoint: target_temp_high (heat_cool/auto) else temperature (cool mode).
   cool_sp: >-
     {% set hi = state_attr(thermostat, 'target_temp_high') %}

--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,20 @@
 """Pytest configuration and fixtures for SmartCocoon integration tests."""
 
-import pytest
+from typing import cast
 
-from homeassistant.core import HomeAssistant
+import pytest
+from pytest_homeassistant_custom_component.common import async_mock_service
+
+from homeassistant.core import HomeAssistant, ServiceCall
 
 
 @pytest.fixture  # type: ignore[untyped-decorator]
 def _hass(hass: HomeAssistant) -> HomeAssistant:
     """Alias for hass fixture to avoid unused argument warnings."""
     return hass
+
+
+@pytest.fixture  # type: ignore[untyped-decorator]
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
+    """Capture fan.set_percentage service calls (used by blueprint tests)."""
+    return cast("list[ServiceCall]", async_mock_service(hass, "fan", "set_percentage"))

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -335,7 +335,9 @@ use_blueprint:
 
 - **Whole-house MAX switch** — create an `input_boolean` (e.g.
   `input_boolean.vent_fans_max`) and point every room's **Force-MAX boolean** input at
-  it. Flip it on to blast every fan to 100%.
+  it. Flip it on to blast every fan to 100%. The blueprint responds **instantly on both
+  edges** (dedicated template triggers), so a dashboard toggle, voice intent, or scene
+  blasts immediately and reclaims control the moment it's turned off.
 - **Speed floor / pre-cool ramp** — create an `input_number` (0–100) and set it as each
   room's **External speed floor**. An external automation (e.g. a sunrise pre-cool) can
   raise the floor without fighting the blueprint — the blueprint stays the sole writer and
@@ -365,17 +367,42 @@ use_blueprint:
             value: 0
   ```
 
+- **Standalone instant-MAX (no blueprint needed)** — if you _aren't_ using the blueprint
+  but still want a "blast all vents" switch, a small automation on a [fan group](#a-fan-group-control-all-vents-at-once)
+  does it:
+
+  ```yaml
+  automation:
+    - alias: "Vent fans — instant MAX"
+      trigger:
+        - platform: state
+          entity_id: input_boolean.vent_fans_max
+          to: "on"
+      action:
+        - service: fan.set_percentage
+          target:
+            entity_id: fan.all_vents
+          data:
+            percentage: 100
+  ```
+
+  With the blueprint, you don't need this — its Force-MAX input already gives instant MAX
+  on both edges. Standalone, note the OFF edge: this recipe only sets 100 on the ON edge,
+  so add a matching `to: "off"` trigger that restores your normal speed if you want the
+  fans to drop back automatically.
+
 ---
 
 ## Caveats
 
 - **Be the sole writer.** The integration doesn't see app-side changes, so let one
   automation own each fan's speed. Mixing the app and HA causes them to fight.
-- **Optional inputs aren't triggers.** The Force-MAX boolean and the external speed
-  floor are optional inputs, so they can't be automation triggers (an unset optional
-  trigger entity makes a blueprint fail to load). Changes to them are picked up on the
-  next re-evaluation — a room/thermostat state change or the periodic tick — **within
-  ~10 minutes**. If you need instant response, drive the fan directly for that one action.
+- **The external speed floor isn't a trigger.** An optional input can't be a state-trigger
+  entity_id (an unset one would make the blueprint fail to load), so a change to the speed
+  floor is picked up on the next re-evaluation — a room/thermostat state change or the
+  periodic tick — **within ~10 minutes**. (The Force-MAX boolean is exempt: it gets
+  dedicated template triggers, so it responds instantly.) If you need an instant floor
+  change, drive the fan directly for that one action.
 - **Night caps.** With night suppression on, the assist/circulate/equalize tiers collapse
   to baseline overnight; only an active heating/cooling boost may exceed baseline. Set
   `night_max_speed` low to prevent a nighttime boost from waking a bedroom.

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -4,6 +4,11 @@ This integration gives you a `fan.*` entity per SmartCocoon booster fan. That's 
 raw building block — this guide turns it into useful control, from one-line recipes to
 a full self-regulating room-climate blueprint.
 
+Everything here uses only standard Home Assistant entities (a `climate` thermostat and a
+temperature `sensor`), so it should work with **any** climate integration. It was
+developed and tested against **Ecobee** — see
+[Compatibility](#compatibility--read-this-first) for the one hard requirement.
+
 It progresses from simplest to most capable:
 
 1. [How the fan behaves in Home Assistant](#how-the-fan-behaves-in-home-assistant)
@@ -31,6 +36,55 @@ A few properties of the fan entity drive everything below:
   Assistant as the **sole writer** of a fan's speed — otherwise HA and the app fight.
 
 The current speed is exposed as the `percentage` attribute of the fan entity.
+
+### Speed & noise — why automate at all
+
+SmartCocoon booster fans trade airflow for noise, and that trade-off is the whole
+reason to automate rather than pick one fixed speed. A rough, anecdotal guide (trust
+your own ears / a dB meter over these numbers):
+
+- **8–16%** — a low, near-silent baseline. Prefer this to fully **OFF**: a powered-but-idle
+  booster fan sitting in a vent can restrict airflow more than the bare register, so a
+  quiet baseline that keeps air moving is usually better than off.
+- **~60%** — clearly audible but tolerable; many people accept it running, some even
+  overnight.
+- **100%** — **LOUD.** Excellent for fast recovery when a room is far off target, but not
+  something you want running continuously or while you sleep.
+
+Automating lets you live in the quiet baseline almost always, step up to ~60% when a
+room drifts, and only hit 100% for short, justified boosts — with **night caps** so a
+boost can't blast a bedroom awake.
+
+### You need a room temperature sensor
+
+Everything here is driven by **room** temperature vs. the thermostat setpoint, so an
+accurate per-room sensor is what makes it effective — without one the automations have
+nothing meaningful to act on. Good sources:
+
+- **Thermostat remote sensors** — Ecobee room sensors, Nest temperature sensors, etc.,
+  exposed as `sensor.*` in Home Assistant.
+- **Standalone sensors** — any Zigbee / Z-Wave / Wi-Fi temperature sensor
+  (`device_class: temperature`).
+
+**Can you use the SmartCocoon fan's own reading?** Not directly. This integration
+registers **only a `fan` entity — there is no dedicated SmartCocoon temperature
+`sensor`.** The fan does carry a `predicted_room_temperature` _attribute_, but (a) it's a
+SmartCocoon _estimate_ (see the `is_room_estimating` attribute), not a direct
+measurement, (b) it isn't always present, and (c) being an attribute rather than a
+`sensor` entity, you can't pick it in the blueprint's sensor selector. If you have
+nothing better, you _can_ wrap it in a template sensor — but a real sensor is strongly
+preferred:
+
+```yaml
+# configuration.yaml — last-resort room sensor from the fan's estimate
+template:
+  - sensor:
+      - name: "Bedroom Room Temp (SmartCocoon estimate)"
+        unit_of_measurement: "°C"
+        device_class: temperature
+        state: "{{ state_attr('fan.bedroom', 'predicted_room_temperature') | float(0) }}"
+        availability: "{{ state_attr('fan.bedroom', 'predicted_room_temperature') is not none }}"
+```
 
 ---
 
@@ -182,35 +236,40 @@ developed and tested against Ecobee.
 
 ### What it does — the speed tiers
 
+The blueprint works **symmetrically for cooling and heating** — a register booster pulls
+warm supply air into a cold room in winter just as it pulls cool air into a hot room in
+summer. "Demand" is how far the room is on the wrong side of the active setpoint:
+`room − cool_setpoint` while cooling, `heat_setpoint − room` while heating (positive =
+escalate). Each direction has its own on/off toggle (**Manage during cooling** /
+**Manage during heating**, both on by default).
+
 Every trigger, the blueprint computes a target speed and only re-commands the fan when
 the current speed is more than one step (>4%) off. From highest priority down:
 
-| Situation                                                       | Speed                                                  |
-| --------------------------------------------------------------- | ------------------------------------------------------ |
-| **Force-MAX** helper ON                                         | `100` (overrides everything, incl. a manually-off fan) |
-| Actively **cooling** and ≥ boost threshold over setpoint        | `boost_speed` (default 100)                            |
-| **Fan-only** (blower on, AC idle) and ≥ threshold over setpoint | `circulate_speed` (default 60)                         |
-| Actively **cooling**, within threshold, daytime                 | `assist_speed` (default 17)                            |
-| **HVAC-off equalizer** (see below)                              | 100 / 60 / 33 by room-vs-house delta                   |
-| Otherwise (idle / heating within range / night-suppressed)      | `baseline_speed` (default 8)                           |
-
-Heating stays at the baseline whisper unless you enable **Apply boost to heating too**.
+| Situation                                                    | Speed                                                  |
+| ------------------------------------------------------------ | ------------------------------------------------------ |
+| **Force-MAX** helper ON                                      | `100` (overrides everything, incl. a manually-off fan) |
+| Actively **heating/cooling** and demand ≥ boost threshold    | `boost_speed` (default 100)                            |
+| **Fan-only** (blower on, no active demand) and demand ≥ thr. | `circulate_speed` (default 60)                         |
+| Actively **heating/cooling**, within threshold, daytime      | `assist_speed` (default 17)                            |
+| **HVAC-off equalizer** (see below)                           | 100 / 60 / 33 by \|room − house\| delta                |
+| Otherwise (idle / within range / night-suppressed)           | `baseline_speed` (default 8)                           |
 
 ### The HVAC-off equalizer
 
-When cooling mode is **off** but the central blower is still circulating and you're home,
-there's no setpoint to chase — so instead the fan equalizes the room toward the _house's_
-current temperature (the thermostat's `current_temperature`, or a reference sensor you
-choose). Tiers on `(room − house)`:
+When the central blower is circulating with **no active heating/cooling demand** and
+you're home, there's no setpoint to chase — so instead the fan equalizes the room toward
+the _house's_ current temperature (the thermostat's `current_temperature`, or a reference
+sensor you choose), **in either direction**. Tiers on `|room − house|`:
 
 - `≥ 2.0 °C` → `100%`
 - `≥ 1.0 °C` → `60%`
 - `≥ 0.5 °C` → `33%`
 - else → baseline
 
-It can only move house-temperature air (it can't cool a room _below_ the house), and it
-respects the away flag and night suppression. Turn it off per room with **Enable HVAC-off
-equalizer**.
+It can only move house-temperature air (it can't push a room _past_ the house temp — no
+cooling below it in summer, no warming above it in winter), and it respects the away flag
+and night suppression. Turn it off per room with **Enable HVAC-off equalizer**.
 
 ### Importing the blueprint
 
@@ -226,12 +285,14 @@ https://github.com/davecpearce/hacs_smartcocoon/blob/main/blueprints/automation/
 > Blueprints bundled inside an integration repo are **not** auto-distributed by HACS —
 > import via the badge/URL above.
 
-### Per-room setup — two examples
+### Per-room setup — examples
 
 Create one automation per room from the blueprint. Only `thermostat`, `room_sensor`, and
-`booster_fan` are required; everything else has a sensible default.
+`booster_fan` are required; everything else has a sensible default. Both directions are
+managed by default — set `enable_cooling` / `enable_heating` to `false` to opt a room out
+of one.
 
-**Bedroom — night caps on (default):**
+**Bedroom — both directions, night caps on (default):**
 
 ```yaml
 use_blueprint:
@@ -255,6 +316,19 @@ use_blueprint:
     booster_fan: fan.office
     enable_night_suppression: false # you work/game late — keep assist/circulate active
     max_speed: 60 # full speed is too loud in here
+```
+
+**Cold back bedroom — heating only:**
+
+```yaml
+use_blueprint:
+  path: smartcocoon/room_climate_boost.yaml
+  input:
+    thermostat: climate.thermostat
+    room_sensor: sensor.back_bedroom_temperature
+    booster_fan: fan.back_bedroom
+    enable_cooling: false # this room only ever runs cold — boost on heating
+    enable_heating: true
 ```
 
 ### Companion helpers (optional)
@@ -303,5 +377,5 @@ use_blueprint:
   next re-evaluation — a room/thermostat state change or the periodic tick — **within
   ~10 minutes**. If you need instant response, drive the fan directly for that one action.
 - **Night caps.** With night suppression on, the assist/circulate/equalize tiers collapse
-  to baseline overnight; only an active-cooling boost may exceed baseline. Set
+  to baseline overnight; only an active heating/cooling boost may exceed baseline. Set
   `night_max_speed` low to prevent a nighttime boost from waking a bedroom.

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -1,0 +1,307 @@
+# SmartCocoon Automations & Blueprints
+
+This integration gives you a `fan.*` entity per SmartCocoon booster fan. That's the
+raw building block — this guide turns it into useful control, from one-line recipes to
+a full self-regulating room-climate blueprint.
+
+It progresses from simplest to most capable:
+
+1. [How the fan behaves in Home Assistant](#how-the-fan-behaves-in-home-assistant)
+2. [Building blocks](#building-blocks) — a speed sensor and a fan group
+3. [Simple recipes](#simple-recipes) — no blueprint required
+4. [Advanced: the Room Climate Boost blueprint](#advanced-the-room-climate-boost-blueprint)
+5. [Caveats](#caveats)
+
+---
+
+## How the fan behaves in Home Assistant
+
+A few properties of the fan entity drive everything below:
+
+- **`fan.set_percentage` is the reliable lever.** Speed is a percentage. The entity
+  reports `speed_count: 100`, so Home Assistant treats it as **continuous 0–100** and
+  the hardware rounds to its nearest physical step. There are no fixed "canonical"
+  speeds to hit — pick whatever percentages read well for your rooms; they're just
+  tunable defaults.
+- **Preset modes (`auto` / `eco`) are optional** and configured in the SmartCocoon app.
+  They're disabled by default and render poorly in Apple Home. For Home-Assistant-driven
+  automation, prefer percentage control and leave presets off (see the README notes).
+- **The integration does not see app-side changes.** If you also drive a fan from the
+  SmartCocoon app, Home Assistant won't know. The cleanest automations treat Home
+  Assistant as the **sole writer** of a fan's speed — otherwise HA and the app fight.
+
+The current speed is exposed as the `percentage` attribute of the fan entity.
+
+---
+
+## Building blocks
+
+### A numeric speed sensor (for graphing / conditions)
+
+The speed lives on the fan as an _attribute_, which you can't graph directly. Expose it
+as a numeric sensor with a template:
+
+```yaml
+# configuration.yaml
+template:
+  - sensor:
+      - name: "Bedroom Fan Speed"
+        unit_of_measurement: "%"
+        state: "{{ state_attr('fan.bedroom', 'percentage') | int(0) }}"
+```
+
+### A fan group (control all vents at once)
+
+Group your booster fans into one entity so recipes can act on every vent together:
+
+```yaml
+# configuration.yaml
+fan:
+  - platform: group
+    name: All Vents
+    entities:
+      - fan.bedroom
+      - fan.office
+      - fan.living_room
+```
+
+You now have `fan.all_vents` for whole-house on/off.
+
+---
+
+## Simple recipes
+
+These are standalone automations — no blueprint needed. They assume a `climate` entity
+(e.g. `climate.thermostat`) and a room temperature `sensor.*`.
+
+### Boost a room when it's hot vs. the setpoint
+
+Turn the fan up when the room runs warmer than the cool setpoint, and back to a quiet
+baseline when it recovers. This is an on/off _pair_ so it re-commands in both directions:
+
+```yaml
+automation:
+  - alias: "Bedroom fan – boost when hot"
+    trigger:
+      - platform: state
+        entity_id: sensor.bedroom_temperature
+    condition:
+      - condition: template
+        value_template: >-
+          {{ (states('sensor.bedroom_temperature') | float(0))
+             - (state_attr('climate.thermostat', 'temperature') | float(99)) >= 1.0 }}
+    action:
+      - service: fan.set_percentage
+        target:
+          entity_id: fan.bedroom
+        data:
+          percentage: 100
+
+  - alias: "Bedroom fan – back to quiet when recovered"
+    trigger:
+      - platform: state
+        entity_id: sensor.bedroom_temperature
+    condition:
+      - condition: template
+        value_template: >-
+          {{ (states('sensor.bedroom_temperature') | float(0))
+             - (state_attr('climate.thermostat', 'temperature') | float(99)) < 0.3 }}
+    action:
+      - service: fan.set_percentage
+        target:
+          entity_id: fan.bedroom
+        data:
+          percentage: 8
+```
+
+### Quiet overnight
+
+Cap a bedroom fan to a whisper during sleeping hours:
+
+```yaml
+automation:
+  - alias: "Bedroom fan – quiet at night"
+    trigger:
+      - platform: time
+        at: "22:00:00"
+    action:
+      - service: fan.set_percentage
+        target:
+          entity_id: fan.bedroom
+        data:
+          percentage: 8
+```
+
+### All vents off when away, on when home
+
+```yaml
+automation:
+  - alias: "Vents off when away"
+    trigger:
+      - platform: state
+        entity_id: input_boolean.away
+        to: "on"
+    action:
+      - service: fan.turn_off
+        target:
+          entity_id: fan.all_vents
+
+  - alias: "Vents on when home"
+    trigger:
+      - platform: state
+        entity_id: input_boolean.away
+        to: "off"
+    action:
+      - service: fan.set_percentage
+        target:
+          entity_id: fan.all_vents
+        data:
+          percentage: 8
+```
+
+---
+
+## Advanced: the Room Climate Boost blueprint
+
+For a room that should **self-regulate**, this repo ships a blueprint at
+[`blueprints/automation/smartcocoon/room_climate_boost.yaml`](../blueprints/automation/smartcocoon/room_climate_boost.yaml).
+Instantiate it once per room; each instance is the sole writer for that room's fan.
+
+### Compatibility — read this first
+
+The blueprint is generic to the `climate` domain. It uses only standard attributes:
+`hvac_action`, `temperature`, `target_temp_high` / `target_temp_low`, and (for the
+equalizer) `current_temperature`. It handles both single-setpoint (`cool` / `heat`) and
+dual-setpoint (`heat_cool` / `auto`) thermostats.
+
+**The one hard requirement: your thermostat must report `hvac_action`.** Some climate
+integrations only report the _mode_ (`cool`/`heat`/`off`) and never the live _action_
+(`cooling`/`heating`/`fan`/`idle`). Without `hvac_action` the blueprint can't tell "AC
+is actively cooling" from "AC is on but idle," and the tier logic won't work. It was
+developed and tested against Ecobee.
+
+### What it does — the speed tiers
+
+Every trigger, the blueprint computes a target speed and only re-commands the fan when
+the current speed is more than one step (>4%) off. From highest priority down:
+
+| Situation                                                       | Speed                                                  |
+| --------------------------------------------------------------- | ------------------------------------------------------ |
+| **Force-MAX** helper ON                                         | `100` (overrides everything, incl. a manually-off fan) |
+| Actively **cooling** and ≥ boost threshold over setpoint        | `boost_speed` (default 100)                            |
+| **Fan-only** (blower on, AC idle) and ≥ threshold over setpoint | `circulate_speed` (default 60)                         |
+| Actively **cooling**, within threshold, daytime                 | `assist_speed` (default 17)                            |
+| **HVAC-off equalizer** (see below)                              | 100 / 60 / 33 by room-vs-house delta                   |
+| Otherwise (idle / heating within range / night-suppressed)      | `baseline_speed` (default 8)                           |
+
+Heating stays at the baseline whisper unless you enable **Apply boost to heating too**.
+
+### The HVAC-off equalizer
+
+When cooling mode is **off** but the central blower is still circulating and you're home,
+there's no setpoint to chase — so instead the fan equalizes the room toward the _house's_
+current temperature (the thermostat's `current_temperature`, or a reference sensor you
+choose). Tiers on `(room − house)`:
+
+- `≥ 2.0 °C` → `100%`
+- `≥ 1.0 °C` → `60%`
+- `≥ 0.5 °C` → `33%`
+- else → baseline
+
+It can only move house-temperature air (it can't cool a room _below_ the house), and it
+respects the away flag and night suppression. Turn it off per room with **Enable HVAC-off
+equalizer**.
+
+### Importing the blueprint
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fdavecpearce%2Fhacs_smartcocoon%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Fsmartcocoon%2Froom_climate_boost.yaml)
+
+Or manually: **Settings → Automations & Scenes → Blueprints → Import Blueprint**, and
+paste:
+
+```
+https://github.com/davecpearce/hacs_smartcocoon/blob/main/blueprints/automation/smartcocoon/room_climate_boost.yaml
+```
+
+> Blueprints bundled inside an integration repo are **not** auto-distributed by HACS —
+> import via the badge/URL above.
+
+### Per-room setup — two examples
+
+Create one automation per room from the blueprint. Only `thermostat`, `room_sensor`, and
+`booster_fan` are required; everything else has a sensible default.
+
+**Bedroom — night caps on (default):**
+
+```yaml
+use_blueprint:
+  path: smartcocoon/room_climate_boost.yaml
+  input:
+    thermostat: climate.thermostat
+    room_sensor: sensor.bedroom_temperature
+    booster_fan: fan.bedroom
+    night_max_speed: 8 # never louder than a whisper overnight
+    enable_night_suppression: true
+```
+
+**Office — runs full tiers 24/7, but quieter ceiling:**
+
+```yaml
+use_blueprint:
+  path: smartcocoon/room_climate_boost.yaml
+  input:
+    thermostat: climate.thermostat
+    room_sensor: sensor.office_temperature
+    booster_fan: fan.office
+    enable_night_suppression: false # you work/game late — keep assist/circulate active
+    max_speed: 60 # full speed is too loud in here
+```
+
+### Companion helpers (optional)
+
+- **Whole-house MAX switch** — create an `input_boolean` (e.g.
+  `input_boolean.vent_fans_max`) and point every room's **Force-MAX boolean** input at
+  it. Flip it on to blast every fan to 100%.
+- **Speed floor / pre-cool ramp** — create an `input_number` (0–100) and set it as each
+  room's **External speed floor**. An external automation (e.g. a sunrise pre-cool) can
+  raise the floor without fighting the blueprint — the blueprint stays the sole writer and
+  can still go higher. Sketch:
+
+  ```yaml
+  automation:
+    - alias: "Sunrise pre-cool ramp"
+      trigger:
+        - platform: sun
+          event: sunrise
+      action:
+        - service: input_number.set_value
+          target:
+            entity_id: input_number.vent_speed_floor
+          data:
+            value: 40
+    - alias: "Clear pre-cool ramp mid-morning"
+      trigger:
+        - platform: time
+          at: "09:00:00"
+      action:
+        - service: input_number.set_value
+          target:
+            entity_id: input_number.vent_speed_floor
+          data:
+            value: 0
+  ```
+
+---
+
+## Caveats
+
+- **Be the sole writer.** The integration doesn't see app-side changes, so let one
+  automation own each fan's speed. Mixing the app and HA causes them to fight.
+- **Optional inputs aren't triggers.** The Force-MAX boolean and the external speed
+  floor are optional inputs, so they can't be automation triggers (an unset optional
+  trigger entity makes a blueprint fail to load). Changes to them are picked up on the
+  next re-evaluation — a room/thermostat state change or the periodic tick — **within
+  ~10 minutes**. If you need instant response, drive the fan directly for that one action.
+- **Night caps.** With night suppression on, the assist/circulate/equalize tiers collapse
+  to baseline overnight; only an active-cooling boost may exceed baseline. Set
+  `night_max_speed` low to prevent a nighttime boost from waking a bedroom.

--- a/tests/test_blueprint_room_climate_boost.py
+++ b/tests/test_blueprint_room_climate_boost.py
@@ -1,0 +1,454 @@
+"""Characterization tests for the Room Climate Boost blueprint.
+
+These lock in the blueprint's *current* behavior as an executable spec, so the
+symmetric-heating refactor can proceed without silently regressing cooling. Each
+test instantiates the real blueprint as an automation (HA core's blueprint test
+pattern), drives entity states, and asserts the ``fan.set_percentage`` the
+automation commands.
+
+The blueprint is YAML, so it does not move the ``custom_components`` coverage
+number -- these tests gate correctness, not coverage.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+from typing import Any
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.setup import async_setup_component
+
+BLUEPRINT_SRC = (
+    pathlib.Path(__file__).parents[1]
+    / "blueprints/automation/smartcocoon/room_climate_boost.yaml"
+)
+BLUEPRINT_REL = "smartcocoon/room_climate_boost.yaml"
+
+THERMOSTAT = "climate.t"
+ROOM = "sensor.room"
+FAN = "fan.test"
+
+DEFAULT_INPUTS = {
+    "thermostat": THERMOSTAT,
+    "room_sensor": ROOM,
+    "booster_fan": FAN,
+}
+
+# A future date (real "today" is 2026-08-xx) so freezing never moves the HA
+# scheduler backwards. Day hour = 12 (outside 22:00-08:00), night hour = 23.
+_DAY = "2026-09-15 12:00:00"
+_NIGHT = "2026-09-15 23:00:00"
+
+
+def _install_blueprint(hass: HomeAssistant) -> None:
+    dest = pathlib.Path(
+        hass.config.path("blueprints/automation/smartcocoon/room_climate_boost.yaml")
+    )
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(BLUEPRINT_SRC, dest)
+
+
+async def _setup(hass: HomeAssistant, inputs: dict[str, Any] | None = None) -> None:
+    """Install the blueprint and instantiate it as a single automation."""
+    merged = {**DEFAULT_INPUTS, **(inputs or {})}
+    # Pin the clock's timezone so frozen UTC times map predictably to the
+    # blueprint's day/night window (the test harness defaults to US/Pacific).
+    await hass.config.async_set_time_zone("UTC")
+    _install_blueprint(hass)
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {"automation": {"use_blueprint": {"path": BLUEPRINT_REL, "input": merged}}},
+    )
+    await hass.async_block_till_done()
+
+
+async def _trigger(
+    hass: HomeAssistant,
+    calls: list[ServiceCall],
+    freezer: FrozenDateTimeFactory,
+    *,
+    hvac_action: str,
+    room: float,
+    mode: str = "cool",
+    when: str = _DAY,
+    temperature: float | None = None,
+    target_temp_high: float | None = None,
+    target_temp_low: float | None = None,
+    current_temperature: float | None = None,
+    fan_state: str = "on",
+    fan_pct: int = 50,
+    helpers: dict[str, str] | None = None,
+) -> None:
+    """Set the world, then change the room sensor to fire the automation."""
+    freezer.move_to(when)
+    for entity, state in (helpers or {}).items():
+        hass.states.async_set(entity, state)
+
+    attrs: dict[str, Any] = {"hvac_action": hvac_action}
+    for key, value in (
+        ("temperature", temperature),
+        ("target_temp_high", target_temp_high),
+        ("target_temp_low", target_temp_low),
+        ("current_temperature", current_temperature),
+    ):
+        if value is not None:
+            attrs[key] = value
+    hass.states.async_set(THERMOSTAT, mode, attrs)
+    hass.states.async_set(
+        FAN, fan_state, {} if fan_state == "off" else {"percentage": fan_pct}
+    )
+    hass.states.async_set(ROOM, "-999")  # prime
+    await hass.async_block_till_done()
+    calls.clear()
+
+    hass.states.async_set(ROOM, str(room))  # the asserted trigger
+    await hass.async_block_till_done()
+
+
+def _last_pct(calls: list[ServiceCall]) -> int:
+    assert calls, "expected a fan.set_percentage call, got none"
+    return int(calls[-1].data["percentage"])
+
+
+# --------------------------------------------------------------------------- #
+# Smoke: the blueprint is a valid, loadable blueprint.
+# --------------------------------------------------------------------------- #
+async def test_blueprint_instantiates(hass: HomeAssistant) -> None:
+    """The blueprint loads and produces an automation entity."""
+    await _setup(hass)
+    automations = hass.states.async_entity_ids("automation")
+    assert automations, "blueprint did not instantiate an automation"
+    state = hass.states.get(automations[0])
+    assert state is not None
+    assert state.state != "unavailable"
+
+
+# --------------------------------------------------------------------------- #
+# Cooling tier ladder.
+# --------------------------------------------------------------------------- #
+async def test_cooling_boost(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """Actively cooling and >= boost threshold over setpoint -> boost (100)."""
+    await _setup(hass)
+    await _trigger(
+        hass, calls, freezer, hvac_action="cooling", target_temp_high=22.0, room=24.0
+    )
+    assert _last_pct(calls) == 100
+
+
+async def test_cooling_assist_daytime(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """Cooling within threshold, daytime -> assist (17)."""
+    await _setup(hass)
+    await _trigger(
+        hass, calls, freezer, hvac_action="cooling", target_temp_high=22.0, room=22.5
+    )
+    assert _last_pct(calls) == 17
+
+
+async def test_fan_only_circulate_daytime(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """Fan-only (blower on, AC idle), room over setpoint -> circulate (60)."""
+    await _setup(hass)
+    await _trigger(
+        hass, calls, freezer, hvac_action="fan", target_temp_high=22.0, room=24.0
+    )
+    assert _last_pct(calls) == 60
+
+
+async def test_baseline_when_idle(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """Idle, room below setpoint -> baseline whisper (8)."""
+    await _setup(hass)
+    await _trigger(
+        hass, calls, freezer, hvac_action="idle", target_temp_high=22.0, room=20.0
+    )
+    assert _last_pct(calls) == 8
+
+
+# --------------------------------------------------------------------------- #
+# HVAC-off equalizer (currently one-directional: only when room warmer than house).
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("room", "expected"),
+    [(24.1, 100), (23.2, 60), (22.6, 33), (22.2, 8)],
+)
+async def test_equalizer_tiers(
+    hass: HomeAssistant,
+    calls: list[ServiceCall],
+    freezer: FrozenDateTimeFactory,
+    room: float,
+    expected: int,
+) -> None:
+    """No cool setpoint, blower circulating, home: equalize toward house temp."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        mode="fan_only",  # not 'cool' and no target_temp_high => cool_sp is None
+        hvac_action="fan",
+        current_temperature=22.0,  # house reference
+        room=room,
+    )
+    assert _last_pct(calls) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Night suppression.
+# --------------------------------------------------------------------------- #
+async def test_night_suppresses_cooling_assist(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """At night, cooling-within-threshold collapses to baseline."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        when=_NIGHT,
+        hvac_action="cooling",
+        target_temp_high=22.0,
+        room=22.5,
+    )
+    assert _last_pct(calls) == 8
+
+
+async def test_night_suppresses_fan_circulate(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """At night, fan-only circulate collapses to baseline."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        when=_NIGHT,
+        hvac_action="fan",
+        target_temp_high=22.0,
+        room=24.0,
+    )
+    assert _last_pct(calls) == 8
+
+
+async def test_night_still_allows_cooling_boost(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """At night, an active-cooling boost is still allowed (not night-gated)."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        when=_NIGHT,
+        hvac_action="cooling",
+        target_temp_high=22.0,
+        room=24.0,
+    )
+    assert _last_pct(calls) == 100
+
+
+# --------------------------------------------------------------------------- #
+# Caps and floor.
+# --------------------------------------------------------------------------- #
+async def test_night_max_cap(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """night_max_speed caps an otherwise-100 boost during the night window."""
+    await _setup(hass, {"night_max_speed": 8})
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        when=_NIGHT,
+        hvac_action="cooling",
+        target_temp_high=22.0,
+        room=24.0,
+    )
+    assert _last_pct(calls) == 8
+
+
+async def test_max_speed_cap(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """max_speed caps the normal automatic speed."""
+    await _setup(hass, {"max_speed": 60})
+    await _trigger(
+        hass, calls, freezer, hvac_action="cooling", target_temp_high=22.0, room=24.0
+    )
+    assert _last_pct(calls) == 60
+
+
+async def test_speed_floor(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """An external speed floor raises an otherwise-baseline speed."""
+    await _setup(hass, {"speed_floor_entity": "input_number.floor"})
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        hvac_action="idle",
+        target_temp_high=22.0,
+        room=20.0,
+        helpers={"input_number.floor": "40"},
+    )
+    assert _last_pct(calls) == 40
+
+
+# --------------------------------------------------------------------------- #
+# Force-max override and manual-off handling.
+# --------------------------------------------------------------------------- #
+async def test_force_max_overrides_everything(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """force_max boolean ON -> 100 regardless of an otherwise-idle state."""
+    await _setup(hass, {"force_max_boolean": "input_boolean.max"})
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        hvac_action="idle",
+        target_temp_high=22.0,
+        room=20.0,
+        helpers={"input_boolean.max": "on"},
+    )
+    assert _last_pct(calls) == 100
+
+
+async def test_manual_off_respected(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """A manually-off fan is left alone (no command) without a force flag."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        hvac_action="cooling",
+        target_temp_high=22.0,
+        room=24.0,
+        fan_state="off",
+    )
+    assert len(calls) == 0
+
+
+async def test_force_manage_ignores_manual_off(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """force_manage ON commands even a manually-off fan."""
+    await _setup(hass, {"force_manage": True})
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        hvac_action="idle",
+        target_temp_high=22.0,
+        room=20.0,
+        fan_state="off",
+    )
+    assert _last_pct(calls) == 8
+
+
+# --------------------------------------------------------------------------- #
+# Sticky release hysteresis.
+# --------------------------------------------------------------------------- #
+async def test_no_premature_boost_below_threshold(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """Not-yet-high + mid-band delta -> assist, not a premature boost."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        hvac_action="cooling",
+        target_temp_high=22.0,
+        room=22.5,  # delta 0.5, below boost threshold 1.0
+        fan_pct=50,  # not currently high
+    )
+    assert _last_pct(calls) == 17
+
+
+async def test_sticky_holds_high_within_band(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """Currently-high + delta still above release -> stays 100 (no re-command)."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        hvac_action="cooling",
+        target_temp_high=22.0,
+        room=22.5,  # delta 0.5 > release 0.3
+        fan_pct=98,  # currently high; desired stays 100, within 4% -> no call
+    )
+    assert len(calls) == 0
+
+
+async def test_release_steps_down_below_release_threshold(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """Currently-high + delta below release threshold -> steps down to assist."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        hvac_action="cooling",
+        target_temp_high=22.0,
+        room=22.2,  # delta 0.2 < release 0.3
+        fan_pct=98,  # currently high
+    )
+    assert _last_pct(calls) == 17
+
+
+# --------------------------------------------------------------------------- #
+# Current cooling-bias: heating gets only the baseline whisper. This expectation
+# is intentionally flipped by the symmetric-heating refactor.
+# --------------------------------------------------------------------------- #
+async def test_heating_is_baseline_only_today(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """Actively heating, room below heat setpoint -> baseline (current bias)."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        mode="heat",
+        hvac_action="heating",
+        target_temp_low=21.0,
+        room=19.0,
+    )
+    assert _last_pct(calls) == 8
+
+
+# --------------------------------------------------------------------------- #
+# Re-command threshold.
+# --------------------------------------------------------------------------- #
+async def test_no_recommand_within_threshold(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """No command when current speed is within one step (<=4%) of desired."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        hvac_action="cooling",
+        target_temp_high=22.0,
+        room=24.0,  # desired 100
+        fan_pct=97,  # within 4% of 100
+    )
+    assert len(calls) == 0

--- a/tests/test_blueprint_room_climate_boost.py
+++ b/tests/test_blueprint_room_climate_boost.py
@@ -1,10 +1,13 @@
 """Characterization tests for the Room Climate Boost blueprint.
 
-These lock in the blueprint's *current* behavior as an executable spec, so the
-symmetric-heating refactor can proceed without silently regressing cooling. Each
-test instantiates the real blueprint as an automation (HA core's blueprint test
+These lock in the blueprint's behavior as an executable spec. Each scenario
+instantiates the real blueprint as an automation (HA core's blueprint test
 pattern), drives entity states, and asserts the ``fan.set_percentage`` the
-automation commands.
+automation commands (or that it stays silent).
+
+Almost every case is the same shape -- set the world, fire a trigger, assert the
+commanded speed -- so they are expressed as one data-driven, parametrized test
+over ``_SCENARIOS`` rather than ~30 near-identical functions.
 
 The blueprint is YAML, so it does not move the ``custom_components`` coverage
 number -- these tests gate correctness, not coverage.
@@ -115,6 +118,25 @@ def _last_pct(calls: list[ServiceCall]) -> int:
     return int(calls[-1].data["percentage"])
 
 
+async def _run_scenario(
+    hass: HomeAssistant,
+    calls: list[ServiceCall],
+    freezer: FrozenDateTimeFactory,
+    case: dict[str, Any],
+) -> None:
+    """Set up (with any per-case inputs), trigger, and assert the outcome.
+
+    ``expected`` is the commanded percentage, or None to assert no command.
+    """
+    await _setup(hass, case.get("inputs"))
+    await _trigger(hass, calls, freezer, **case["trigger"])
+    expected = case["expected"]
+    if expected is None:
+        assert len(calls) == 0, f"expected no command, got {calls}"
+    else:
+        assert _last_pct(calls) == expected
+
+
 # --------------------------------------------------------------------------- #
 # Smoke: the blueprint is a valid, loadable blueprint.
 # --------------------------------------------------------------------------- #
@@ -129,454 +151,408 @@ async def test_blueprint_instantiates(hass: HomeAssistant) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Cooling tier ladder.
+# Behavior matrix. Each case: optional setup `inputs`, the `trigger` state, and
+# the `expected` commanded percentage (None = no command). Defaults: boost=100,
+# circulate=60, assist=17, baseline=8, boost_threshold=1.0, release=0.3.
 # --------------------------------------------------------------------------- #
-async def test_cooling_boost(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """Actively cooling and >= boost threshold over setpoint -> boost (100)."""
-    await _setup(hass)
-    await _trigger(
-        hass, calls, freezer, hvac_action="cooling", target_temp_high=22.0, room=24.0
-    )
-    assert _last_pct(calls) == 100
+_SCENARIOS = [
+    # --- cooling tier ladder ---
+    pytest.param(
+        {
+            "trigger": {
+                "hvac_action": "cooling",
+                "target_temp_high": 22.0,
+                "room": 24.0,
+            },
+            "expected": 100,
+        },
+        id="cooling-boost",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "hvac_action": "cooling",
+                "target_temp_high": 22.0,
+                "room": 22.5,
+            },
+            "expected": 17,
+        },
+        id="cooling-assist-daytime",
+    ),
+    pytest.param(
+        {
+            "trigger": {"hvac_action": "fan", "target_temp_high": 22.0, "room": 24.0},
+            "expected": 60,
+        },
+        id="fan-only-circulate-cooling",
+    ),
+    pytest.param(
+        {
+            "trigger": {"hvac_action": "idle", "target_temp_high": 22.0, "room": 20.0},
+            "expected": 8,
+        },
+        id="baseline-when-idle",
+    ),
+    # --- heating tier ladder (symmetric) ---
+    pytest.param(
+        {
+            "trigger": {
+                "mode": "heat",
+                "hvac_action": "heating",
+                "target_temp_low": 21.0,
+                "room": 19.0,
+            },
+            "expected": 100,
+        },
+        id="heating-boost",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "mode": "heat",
+                "hvac_action": "heating",
+                "target_temp_low": 21.0,
+                "room": 20.5,
+            },
+            "expected": 17,
+        },
+        id="heating-assist-daytime",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "mode": "heat",
+                "hvac_action": "fan",
+                "target_temp_low": 21.0,
+                "room": 19.0,
+            },
+            "expected": 60,
+        },
+        id="fan-only-circulate-heating",
+    ),
+    # --- HVAC-off equalizer, bidirectional (tiers on |room - house|) ---
+    pytest.param(
+        {
+            "trigger": {
+                "mode": "fan_only",
+                "hvac_action": "fan",
+                "current_temperature": 22.0,
+                "room": 24.1,
+            },
+            "expected": 100,
+        },
+        id="equalizer-warm-2.1",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "mode": "fan_only",
+                "hvac_action": "fan",
+                "current_temperature": 22.0,
+                "room": 23.2,
+            },
+            "expected": 60,
+        },
+        id="equalizer-warm-1.2",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "mode": "fan_only",
+                "hvac_action": "fan",
+                "current_temperature": 22.0,
+                "room": 22.6,
+            },
+            "expected": 33,
+        },
+        id="equalizer-warm-0.6",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "mode": "fan_only",
+                "hvac_action": "fan",
+                "current_temperature": 22.0,
+                "room": 22.2,
+            },
+            "expected": 8,
+        },
+        id="equalizer-warm-0.2",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "mode": "fan_only",
+                "hvac_action": "fan",
+                "current_temperature": 22.0,
+                "room": 19.9,
+            },
+            "expected": 100,
+        },
+        id="equalizer-cold-2.1",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "mode": "fan_only",
+                "hvac_action": "fan",
+                "current_temperature": 22.0,
+                "room": 20.8,
+            },
+            "expected": 60,
+        },
+        id="equalizer-cold-1.2",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "mode": "fan_only",
+                "hvac_action": "fan",
+                "current_temperature": 22.0,
+                "room": 21.4,
+            },
+            "expected": 33,
+        },
+        id="equalizer-cold-0.6",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "mode": "fan_only",
+                "hvac_action": "fan",
+                "current_temperature": 22.0,
+                "room": 21.8,
+            },
+            "expected": 8,
+        },
+        id="equalizer-cold-0.2",
+    ),
+    # --- night suppression ---
+    pytest.param(
+        {
+            "trigger": {
+                "when": _NIGHT,
+                "hvac_action": "cooling",
+                "target_temp_high": 22.0,
+                "room": 22.5,
+            },
+            "expected": 8,
+        },
+        id="night-suppresses-cooling-assist",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "when": _NIGHT,
+                "hvac_action": "fan",
+                "target_temp_high": 22.0,
+                "room": 24.0,
+            },
+            "expected": 8,
+        },
+        id="night-suppresses-fan-circulate",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "when": _NIGHT,
+                "hvac_action": "cooling",
+                "target_temp_high": 22.0,
+                "room": 24.0,
+            },
+            "expected": 100,
+        },
+        id="night-still-allows-cooling-boost",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "when": _NIGHT,
+                "mode": "heat",
+                "hvac_action": "heating",
+                "target_temp_low": 21.0,
+                "room": 19.0,
+            },
+            "expected": 100,
+        },
+        id="night-still-allows-heating-boost",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "when": _NIGHT,
+                "mode": "heat",
+                "hvac_action": "heating",
+                "target_temp_low": 21.0,
+                "room": 20.5,
+            },
+            "expected": 8,
+        },
+        id="night-suppresses-heating-assist",
+    ),
+    # --- caps and floor ---
+    pytest.param(
+        {
+            "inputs": {"night_max_speed": 8},
+            "trigger": {
+                "when": _NIGHT,
+                "hvac_action": "cooling",
+                "target_temp_high": 22.0,
+                "room": 24.0,
+            },
+            "expected": 8,
+        },
+        id="night-max-cap",
+    ),
+    pytest.param(
+        {
+            "inputs": {"max_speed": 60},
+            "trigger": {
+                "hvac_action": "cooling",
+                "target_temp_high": 22.0,
+                "room": 24.0,
+            },
+            "expected": 60,
+        },
+        id="max-speed-cap",
+    ),
+    pytest.param(
+        {
+            "inputs": {"speed_floor_entity": "input_number.floor"},
+            "trigger": {
+                "hvac_action": "idle",
+                "target_temp_high": 22.0,
+                "room": 20.0,
+                "helpers": {"input_number.floor": "40"},
+            },
+            "expected": 40,
+        },
+        id="speed-floor",
+    ),
+    # --- force-max override and manual-off handling ---
+    pytest.param(
+        {
+            "inputs": {"force_max_boolean": "input_boolean.max"},
+            "trigger": {
+                "hvac_action": "idle",
+                "target_temp_high": 22.0,
+                "room": 20.0,
+                "helpers": {"input_boolean.max": "on"},
+            },
+            "expected": 100,
+        },
+        id="force-max-overrides-everything",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "hvac_action": "cooling",
+                "target_temp_high": 22.0,
+                "room": 24.0,
+                "fan_state": "off",
+            },
+            "expected": None,
+        },
+        id="manual-off-respected",
+    ),
+    pytest.param(
+        {
+            "inputs": {"force_manage": True},
+            "trigger": {
+                "hvac_action": "idle",
+                "target_temp_high": 22.0,
+                "room": 20.0,
+                "fan_state": "off",
+            },
+            "expected": 8,
+        },
+        id="force-manage-ignores-manual-off",
+    ),
+    # --- sticky release hysteresis ---
+    pytest.param(
+        {
+            "trigger": {
+                "hvac_action": "cooling",
+                "target_temp_high": 22.0,
+                "room": 22.5,
+                "fan_pct": 50,
+            },
+            "expected": 17,
+        },
+        id="no-premature-boost-below-threshold",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "hvac_action": "cooling",
+                "target_temp_high": 22.0,
+                "room": 22.5,
+                "fan_pct": 98,
+            },
+            "expected": None,
+        },
+        id="sticky-holds-high-within-band",
+    ),
+    pytest.param(
+        {
+            "trigger": {
+                "hvac_action": "cooling",
+                "target_temp_high": 22.0,
+                "room": 22.2,
+                "fan_pct": 98,
+            },
+            "expected": 17,
+        },
+        id="release-steps-down-below-release-threshold",
+    ),
+    # --- enable toggles gate each direction ---
+    pytest.param(
+        {
+            "inputs": {"enable_cooling": False},
+            "trigger": {
+                "hvac_action": "cooling",
+                "target_temp_high": 22.0,
+                "room": 24.0,
+            },
+            "expected": 8,
+        },
+        id="enable-cooling-false-leaves-baseline",
+    ),
+    pytest.param(
+        {
+            "inputs": {"enable_heating": False},
+            "trigger": {
+                "mode": "heat",
+                "hvac_action": "heating",
+                "target_temp_low": 21.0,
+                "room": 19.0,
+            },
+            "expected": 8,
+        },
+        id="enable-heating-false-leaves-baseline",
+    ),
+    # --- re-command threshold ---
+    pytest.param(
+        {
+            "trigger": {
+                "hvac_action": "cooling",
+                "target_temp_high": 22.0,
+                "room": 24.0,
+                "fan_pct": 97,
+            },
+            "expected": None,
+        },
+        id="no-recommand-within-threshold",
+    ),
+]
 
 
-async def test_cooling_assist_daytime(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """Cooling within threshold, daytime -> assist (17)."""
-    await _setup(hass)
-    await _trigger(
-        hass, calls, freezer, hvac_action="cooling", target_temp_high=22.0, room=22.5
-    )
-    assert _last_pct(calls) == 17
-
-
-async def test_fan_only_circulate_daytime(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """Fan-only (blower on, AC idle), room over setpoint -> circulate (60)."""
-    await _setup(hass)
-    await _trigger(
-        hass, calls, freezer, hvac_action="fan", target_temp_high=22.0, room=24.0
-    )
-    assert _last_pct(calls) == 60
-
-
-async def test_baseline_when_idle(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """Idle, room below setpoint -> baseline whisper (8)."""
-    await _setup(hass)
-    await _trigger(
-        hass, calls, freezer, hvac_action="idle", target_temp_high=22.0, room=20.0
-    )
-    assert _last_pct(calls) == 8
-
-
-# --------------------------------------------------------------------------- #
-# HVAC-off equalizer (currently one-directional: only when room warmer than house).
-# --------------------------------------------------------------------------- #
-@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
-    ("room", "expected"),
-    [(24.1, 100), (23.2, 60), (22.6, 33), (22.2, 8)],
-)
-async def test_equalizer_tiers(
+@pytest.mark.parametrize("case", _SCENARIOS)  # type: ignore[untyped-decorator]
+async def test_speed_scenario(
     hass: HomeAssistant,
     calls: list[ServiceCall],
     freezer: FrozenDateTimeFactory,
-    room: float,
-    expected: int,
+    case: dict[str, Any],
 ) -> None:
-    """No cool setpoint, blower circulating, home: equalize toward house temp."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        mode="fan_only",  # not 'cool' and no target_temp_high => cool_sp is None
-        hvac_action="fan",
-        current_temperature=22.0,  # house reference
-        room=room,
-    )
-    assert _last_pct(calls) == expected
-
-
-# --------------------------------------------------------------------------- #
-# Night suppression.
-# --------------------------------------------------------------------------- #
-async def test_night_suppresses_cooling_assist(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """At night, cooling-within-threshold collapses to baseline."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        when=_NIGHT,
-        hvac_action="cooling",
-        target_temp_high=22.0,
-        room=22.5,
-    )
-    assert _last_pct(calls) == 8
-
-
-async def test_night_suppresses_fan_circulate(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """At night, fan-only circulate collapses to baseline."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        when=_NIGHT,
-        hvac_action="fan",
-        target_temp_high=22.0,
-        room=24.0,
-    )
-    assert _last_pct(calls) == 8
-
-
-async def test_night_still_allows_cooling_boost(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """At night, an active-cooling boost is still allowed (not night-gated)."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        when=_NIGHT,
-        hvac_action="cooling",
-        target_temp_high=22.0,
-        room=24.0,
-    )
-    assert _last_pct(calls) == 100
-
-
-# --------------------------------------------------------------------------- #
-# Caps and floor.
-# --------------------------------------------------------------------------- #
-async def test_night_max_cap(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """night_max_speed caps an otherwise-100 boost during the night window."""
-    await _setup(hass, {"night_max_speed": 8})
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        when=_NIGHT,
-        hvac_action="cooling",
-        target_temp_high=22.0,
-        room=24.0,
-    )
-    assert _last_pct(calls) == 8
-
-
-async def test_max_speed_cap(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """max_speed caps the normal automatic speed."""
-    await _setup(hass, {"max_speed": 60})
-    await _trigger(
-        hass, calls, freezer, hvac_action="cooling", target_temp_high=22.0, room=24.0
-    )
-    assert _last_pct(calls) == 60
-
-
-async def test_speed_floor(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """An external speed floor raises an otherwise-baseline speed."""
-    await _setup(hass, {"speed_floor_entity": "input_number.floor"})
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        hvac_action="idle",
-        target_temp_high=22.0,
-        room=20.0,
-        helpers={"input_number.floor": "40"},
-    )
-    assert _last_pct(calls) == 40
-
-
-# --------------------------------------------------------------------------- #
-# Force-max override and manual-off handling.
-# --------------------------------------------------------------------------- #
-async def test_force_max_overrides_everything(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """force_max boolean ON -> 100 regardless of an otherwise-idle state."""
-    await _setup(hass, {"force_max_boolean": "input_boolean.max"})
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        hvac_action="idle",
-        target_temp_high=22.0,
-        room=20.0,
-        helpers={"input_boolean.max": "on"},
-    )
-    assert _last_pct(calls) == 100
-
-
-async def test_manual_off_respected(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """A manually-off fan is left alone (no command) without a force flag."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        hvac_action="cooling",
-        target_temp_high=22.0,
-        room=24.0,
-        fan_state="off",
-    )
-    assert len(calls) == 0
-
-
-async def test_force_manage_ignores_manual_off(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """force_manage ON commands even a manually-off fan."""
-    await _setup(hass, {"force_manage": True})
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        hvac_action="idle",
-        target_temp_high=22.0,
-        room=20.0,
-        fan_state="off",
-    )
-    assert _last_pct(calls) == 8
-
-
-# --------------------------------------------------------------------------- #
-# Sticky release hysteresis.
-# --------------------------------------------------------------------------- #
-async def test_no_premature_boost_below_threshold(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """Not-yet-high + mid-band delta -> assist, not a premature boost."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        hvac_action="cooling",
-        target_temp_high=22.0,
-        room=22.5,  # delta 0.5, below boost threshold 1.0
-        fan_pct=50,  # not currently high
-    )
-    assert _last_pct(calls) == 17
-
-
-async def test_sticky_holds_high_within_band(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """Currently-high + delta still above release -> stays 100 (no re-command)."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        hvac_action="cooling",
-        target_temp_high=22.0,
-        room=22.5,  # delta 0.5 > release 0.3
-        fan_pct=98,  # currently high; desired stays 100, within 4% -> no call
-    )
-    assert len(calls) == 0
-
-
-async def test_release_steps_down_below_release_threshold(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """Currently-high + delta below release threshold -> steps down to assist."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        hvac_action="cooling",
-        target_temp_high=22.0,
-        room=22.2,  # delta 0.2 < release 0.3
-        fan_pct=98,  # currently high
-    )
-    assert _last_pct(calls) == 17
-
-
-# --------------------------------------------------------------------------- #
-# Heating tier ladder (symmetric with cooling).
-# --------------------------------------------------------------------------- #
-async def test_heating_boost(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """Actively heating and >= boost threshold below setpoint -> boost (100)."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        mode="heat",
-        hvac_action="heating",
-        target_temp_low=21.0,
-        room=19.0,  # 2.0 below heat setpoint
-    )
-    assert _last_pct(calls) == 100
-
-
-async def test_heating_assist_daytime(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """Heating within threshold, daytime -> assist (17)."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        mode="heat",
-        hvac_action="heating",
-        target_temp_low=21.0,
-        room=20.5,  # 0.5 below setpoint, within boost threshold
-    )
-    assert _last_pct(calls) == 17
-
-
-async def test_fan_only_circulate_heating(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """Fan-only, room below heat setpoint -> circulate (60)."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        mode="heat",  # cool_sp is None; heat_sp comes from target_temp_low
-        hvac_action="fan",
-        target_temp_low=21.0,
-        room=19.0,
-    )
-    assert _last_pct(calls) == 60
-
-
-async def test_night_still_allows_heating_boost(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """At night, an active-heating boost is still allowed."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        when=_NIGHT,
-        mode="heat",
-        hvac_action="heating",
-        target_temp_low=21.0,
-        room=19.0,
-    )
-    assert _last_pct(calls) == 100
-
-
-async def test_night_suppresses_heating_assist(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """At night, heating-within-threshold collapses to baseline."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        when=_NIGHT,
-        mode="heat",
-        hvac_action="heating",
-        target_temp_low=21.0,
-        room=20.5,
-    )
-    assert _last_pct(calls) == 8
-
-
-# --------------------------------------------------------------------------- #
-# Bidirectional equalizer: room COLDER than the house pulls warm air in too.
-# --------------------------------------------------------------------------- #
-@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
-    ("room", "expected"),
-    [(19.9, 100), (20.8, 60), (21.4, 33), (21.8, 8)],
-)
-async def test_equalizer_tiers_room_colder_than_house(
-    hass: HomeAssistant,
-    calls: list[ServiceCall],
-    freezer: FrozenDateTimeFactory,
-    room: float,
-    expected: int,
-) -> None:
-    """No setpoint, blower circulating, home: equalize a cold room toward the house."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        mode="fan_only",
-        hvac_action="fan",
-        current_temperature=22.0,  # house is warmer than the room
-        room=room,
-    )
-    assert _last_pct(calls) == expected
-
-
-# --------------------------------------------------------------------------- #
-# Enable toggles gate each direction.
-# --------------------------------------------------------------------------- #
-async def test_enable_cooling_false_leaves_baseline(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """With cooling management off, an otherwise-boost case stays at baseline."""
-    await _setup(hass, {"enable_cooling": False})
-    await _trigger(
-        hass, calls, freezer, hvac_action="cooling", target_temp_high=22.0, room=24.0
-    )
-    assert _last_pct(calls) == 8
-
-
-async def test_enable_heating_false_leaves_baseline(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """With heating management off, an otherwise-boost case stays at baseline."""
-    await _setup(hass, {"enable_heating": False})
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        mode="heat",
-        hvac_action="heating",
-        target_temp_low=21.0,
-        room=19.0,
-    )
-    assert _last_pct(calls) == 8
-
-
-# --------------------------------------------------------------------------- #
-# Re-command threshold.
-# --------------------------------------------------------------------------- #
-async def test_no_recommand_within_threshold(
-    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
-) -> None:
-    """No command when current speed is within one step (<=4%) of desired."""
-    await _setup(hass)
-    await _trigger(
-        hass,
-        calls,
-        freezer,
-        hvac_action="cooling",
-        target_temp_high=22.0,
-        room=24.0,  # desired 100
-        fan_pct=97,  # within 4% of 100
-    )
-    assert len(calls) == 0
+    """Drive the blueprint through one scenario and assert the commanded speed."""
+    await _run_scenario(hass, calls, freezer, case)

--- a/tests/test_blueprint_room_climate_boost.py
+++ b/tests/test_blueprint_room_climate_boost.py
@@ -556,3 +556,70 @@ async def test_speed_scenario(
 ) -> None:
     """Drive the blueprint through one scenario and assert the commanded speed."""
     await _run_scenario(hass, calls, freezer, case)
+
+
+# --------------------------------------------------------------------------- #
+# Instant whole-house MAX hook: dedicated template triggers on the force_max
+# helper fire on the toggle itself (not a room-sensor change), so these are
+# separate from the scenario matrix. They also prove the unset-safe property:
+# with no force_max_boolean the blueprint must still load and never fire.
+# --------------------------------------------------------------------------- #
+_MAX_HELPER = "input_boolean.max"
+
+
+def _prime_idle(hass: HomeAssistant, fan_pct: int) -> None:
+    """Idle + room below setpoint -> desired baseline (8)."""
+    hass.states.async_set(
+        THERMOSTAT, "cool", {"hvac_action": "idle", "target_temp_high": 22.0}
+    )
+    hass.states.async_set(FAN, "on", {"percentage": fan_pct})
+    hass.states.async_set(ROOM, "20.0")
+
+
+async def test_instant_max_on_edge(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Turning the MAX helper ON commands 100 immediately (no room change)."""
+    await _setup(hass, {"force_max_boolean": _MAX_HELPER})
+    hass.states.async_set(_MAX_HELPER, "off")
+    _prime_idle(hass, fan_pct=8)
+    await hass.async_block_till_done()
+    calls.clear()
+
+    hass.states.async_set(_MAX_HELPER, "on")  # only change
+    await hass.async_block_till_done()
+    assert _last_pct(calls) == 100
+
+
+async def test_instant_max_off_edge(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Turning MAX OFF immediately reclaims the real speed (not stuck at 100)."""
+    await _setup(hass, {"force_max_boolean": _MAX_HELPER})
+    hass.states.async_set(_MAX_HELPER, "on")
+    _prime_idle(hass, fan_pct=100)
+    await hass.async_block_till_done()
+    calls.clear()
+
+    hass.states.async_set(_MAX_HELPER, "off")  # only change
+    await hass.async_block_till_done()
+    assert _last_pct(calls) == 8
+
+
+async def test_max_hook_unset_loads_and_is_quiet(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """With force_max_boolean unset, the blueprint loads and never spuriously fires."""
+    await _setup(hass)  # no force_max_boolean
+    automations = hass.states.async_entity_ids("automation")
+    assert automations, "blueprint failed to load when force_max_boolean is unset"
+    state = hass.states.get(automations[0])
+    assert state is not None
+    assert state.state == "on"
+
+    _prime_idle(hass, fan_pct=8)
+    await hass.async_block_till_done()
+    calls.clear()
+    hass.states.async_set("input_boolean.unrelated", "on")
+    await hass.async_block_till_done()
+    assert len(calls) == 0

--- a/tests/test_blueprint_room_climate_boost.py
+++ b/tests/test_blueprint_room_climate_boost.py
@@ -414,14 +414,142 @@ async def test_release_steps_down_below_release_threshold(
 
 
 # --------------------------------------------------------------------------- #
-# Current cooling-bias: heating gets only the baseline whisper. This expectation
-# is intentionally flipped by the symmetric-heating refactor.
+# Heating tier ladder (symmetric with cooling).
 # --------------------------------------------------------------------------- #
-async def test_heating_is_baseline_only_today(
+async def test_heating_boost(
     hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
 ) -> None:
-    """Actively heating, room below heat setpoint -> baseline (current bias)."""
+    """Actively heating and >= boost threshold below setpoint -> boost (100)."""
     await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        mode="heat",
+        hvac_action="heating",
+        target_temp_low=21.0,
+        room=19.0,  # 2.0 below heat setpoint
+    )
+    assert _last_pct(calls) == 100
+
+
+async def test_heating_assist_daytime(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """Heating within threshold, daytime -> assist (17)."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        mode="heat",
+        hvac_action="heating",
+        target_temp_low=21.0,
+        room=20.5,  # 0.5 below setpoint, within boost threshold
+    )
+    assert _last_pct(calls) == 17
+
+
+async def test_fan_only_circulate_heating(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """Fan-only, room below heat setpoint -> circulate (60)."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        mode="heat",  # cool_sp is None; heat_sp comes from target_temp_low
+        hvac_action="fan",
+        target_temp_low=21.0,
+        room=19.0,
+    )
+    assert _last_pct(calls) == 60
+
+
+async def test_night_still_allows_heating_boost(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """At night, an active-heating boost is still allowed."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        when=_NIGHT,
+        mode="heat",
+        hvac_action="heating",
+        target_temp_low=21.0,
+        room=19.0,
+    )
+    assert _last_pct(calls) == 100
+
+
+async def test_night_suppresses_heating_assist(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """At night, heating-within-threshold collapses to baseline."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        when=_NIGHT,
+        mode="heat",
+        hvac_action="heating",
+        target_temp_low=21.0,
+        room=20.5,
+    )
+    assert _last_pct(calls) == 8
+
+
+# --------------------------------------------------------------------------- #
+# Bidirectional equalizer: room COLDER than the house pulls warm air in too.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("room", "expected"),
+    [(19.9, 100), (20.8, 60), (21.4, 33), (21.8, 8)],
+)
+async def test_equalizer_tiers_room_colder_than_house(
+    hass: HomeAssistant,
+    calls: list[ServiceCall],
+    freezer: FrozenDateTimeFactory,
+    room: float,
+    expected: int,
+) -> None:
+    """No setpoint, blower circulating, home: equalize a cold room toward the house."""
+    await _setup(hass)
+    await _trigger(
+        hass,
+        calls,
+        freezer,
+        mode="fan_only",
+        hvac_action="fan",
+        current_temperature=22.0,  # house is warmer than the room
+        room=room,
+    )
+    assert _last_pct(calls) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Enable toggles gate each direction.
+# --------------------------------------------------------------------------- #
+async def test_enable_cooling_false_leaves_baseline(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """With cooling management off, an otherwise-boost case stays at baseline."""
+    await _setup(hass, {"enable_cooling": False})
+    await _trigger(
+        hass, calls, freezer, hvac_action="cooling", target_temp_high=22.0, room=24.0
+    )
+    assert _last_pct(calls) == 8
+
+
+async def test_enable_heating_false_leaves_baseline(
+    hass: HomeAssistant, calls: list[ServiceCall], freezer: FrozenDateTimeFactory
+) -> None:
+    """With heating management off, an otherwise-boost case stays at baseline."""
+    await _setup(hass, {"enable_heating": False})
     await _trigger(
         hass,
         calls,


### PR DESCRIPTION
## Proposal (fully tested) — feedback very welcome

This is offered as a **proposal**, not a take-it-or-leave-it drop: I'd love your steer on
scope, naming, and conventions. That said, it's **fully tested** — 33 dedicated blueprint
tests plus a live canary soak on real hardware (details below).

Happy to split, rename, trim, or rework any of it to fit how you'd like the integration to grow.

## Why

The integration gives users a great `fan.*` entity per booster fan — but then everyone has
to invent useful control from scratch. The most common thing people actually want is
"make this room track my thermostat," and getting that right (quiet baseline, sane
escalation, night behaviour, not fighting the app) is fiddly.

This adds a **turnkey, opt-in blueprint** so that anyone who already has a `climate` entity
wired up can go from "I have a fan entity" to "my hot/cold room self-regulates" in a couple
of clicks — **per-room**, which is the big win: each room gets its own thresholds, speed
caps, night limits, and enable toggles.

**Nothing here changes the integration's behaviour** — it's additive (a blueprint, docs, and
tests). Users who don't import the blueprint see no difference.

## What's included

- `blueprints/automation/smartcocoon/room_climate_boost.yaml` — the blueprint.
- `docs/AUTOMATIONS.md` — an automation cookbook: fan behaviour in HA, simple standalone
  recipes, then the blueprint with worked per-room examples and an import badge.
- `README.md` — a short `## Automations & Blueprints` section linking the above.
- `tests/test_blueprint_room_climate_boost.py` (+ a shared `conftest.py` fixture) — 33 tests
  that instantiate the blueprint as an automation and assert the commanded `fan.set_percentage`.
- `.pre-commit-config.yaml` — one small change; see the note at the bottom.

## What the blueprint does

- **Generic to the `climate` domain.** Uses only standard attributes (`hvac_action`,
  `temperature`, `target_temp_high`/`_low`, `current_temperature`); handles single- and
  dual-setpoint thermostats. The one hard requirement (documented up front): the thermostat
  must report `hvac_action`. Developed and tested against **Ecobee**.
- **Symmetric cooling + heating.** A signed "demand" (`room − cool_sp` cooling,
  `heat_sp − room` heating) drives one boost / circulate / assist / baseline ladder, with
  independent `enable_cooling` / `enable_heating` toggles (both default on). A register
  booster pulls warm supply air into a cold room in winter just as it pulls cool air in summer.
- **Per-room config**: boost/release thresholds, tunable speeds, `max_speed` + night caps,
  an HVAC-off "equalizer" (evens a room toward the house temperature, both directions), an
  optional whole-house MAX override, and an optional external speed floor.
- **Percentage-only control** (matches the README guidance that preset modes render poorly
  in Apple Home) and designed to be the **sole writer** of a fan's speed (since the
  integration doesn't see app-side changes).
- **Instant whole-house MAX** on both edges via unset-safe template triggers.

## Testing

- **33 blueprint tests** — cooling + heating boost/assist/fan-only-circulate, night
  suppression + caps, speed floor, force-max, manual-off, sticky-release hysteresis, the
  bidirectional equalizer, and the enable toggles. They instantiate the real blueprint as an
  automation (HA core's blueprint test pattern) and assert the commanded percentage.
- Green under the repo's own gates (pre-commit + `pytest`, HA pinned by
  `pytest-homeassistant-custom-component`). Full suite passes.
- **Live canary soak**: deployed to a production HAOS instance (HA 2026.7.4, Ecobee + 2
  SmartCocoon fans) with one room on this blueprint and one kept as an A/B control.
  `ha core check` clean; a real trigger confirmed the cooling tier + `max_speed` cap
  end-to-end; instant-MAX confirmed on both edges; no rejected-command errors over a week.
  (Heating is validated by unit tests but stays winter-gated in the live soak.)

## Iteration / testing history

Full development and testing history — including the earlier review rounds, the symmetric-heating
refactor, and the live soak notes — is on the fork PR:
**fermulator/hacs_smartcocoon#1** (https://github.com/fermulator/hacs_smartcocoon/pull/1).

## Notes for review

- **`.pre-commit-config.yaml`:** HA blueprints use custom YAML tags (`!input`), which the
  repo's `check-yaml` hook rejects (and CI runs `pre-commit --all-files`). I split it into a
  strict `check-yaml` that **excludes** `blueprints/**` plus a scoped `check-yaml --unsafe`
  **for** `blueprints/**` (syntax-only, allows the tags). Happy to collapse this to a single
  `--unsafe` on the existing hook if you prefer the one-liner.
- **`source_url` / import badge** point at the intended upstream path
  (`davecpearce/main/blueprints/...`), so they resolve once merged — no post-merge edit needed.
- Blueprints bundled in an integration repo aren't auto-distributed by HACS; the docs give
  the My-HA import badge + URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
